### PR TITLE
Fix some error with manifests

### DIFF
--- a/api/downloads/download-file.js
+++ b/api/downloads/download-file.js
@@ -160,10 +160,10 @@ DownloadFile.prototype._onDownloadFailure = function (err, aborted) {
     if (this._errors <= this._options.maxDownloadRetry) {
       this._retryDownload();
     } else {
-      this.emit("error", err);
+      this.emit("error", { message: err});
     }
   } else {
-    this.emit("error", err);
+    this.emit("error", { message: err});
   }
 
 };

--- a/api/downloads/download-file.js
+++ b/api/downloads/download-file.js
@@ -160,10 +160,10 @@ DownloadFile.prototype._onDownloadFailure = function (err, aborted) {
     if (this._errors <= this._options.maxDownloadRetry) {
       this._retryDownload();
     } else {
-      this.emit("error", { message: err});
+      this.emit("error", {message: err});
     }
   } else {
-    this.emit("error", { message: err});
+    this.emit("error", {message: err});
   }
 
 };

--- a/api/downloads/download-file.js
+++ b/api/downloads/download-file.js
@@ -160,10 +160,10 @@ DownloadFile.prototype._onDownloadFailure = function (err, aborted) {
     if (this._errors <= this._options.maxDownloadRetry) {
       this._retryDownload();
     } else {
-      this.emit("error", {message: err});
+      this.emit("error", { message: err});
     }
   } else {
-    this.emit("error", {message: err});
+    this.emit("error", { message: err});
   }
 
 };

--- a/api/manifest/parser/segment-information.js
+++ b/api/manifest/parser/segment-information.js
@@ -163,6 +163,10 @@ const SegmentInformation = (function () {
     const segmentDuration = parseInt(this.segmentTemplate.attributes.getNamedItem("duration").nodeValue);
     const segmentTimescale = (this.segmentTemplate.attributes.getNamedItem("timescale")) ? parseInt(
         this.segmentTemplate.attributes.getNamedItem("timescale").nodeValue) : 1;
+
+    // use math.ceil, instead of math.floor, because floor returns the largest integer less than or equal to a given number.
+    // math.ceil returns the smallest integer greater than or equal to a given number.
+    // using math.floor may lead to an incorrect number of segments.
     const numSegments = Math.ceil(this.presentationDuration / (segmentDuration / segmentTimescale) / 1000);
     const mediaTemplateStringSegment = this.mediaTemplate.split('$');
     let templateReplaceableIndex;
@@ -173,6 +177,7 @@ const SegmentInformation = (function () {
       }
     }
     const paddingAmount = ZeroPadding_1.ZeroPadding.getPaddingAmount(templateReplaceableIndex);
+    // end condition of loop must be strictly inferior (to avoid to compute too many mediaUrls)
     for (let i = startNumber; i < numSegments + startNumber; i++) {
       const segmentIndex = ZeroPadding_1.ZeroPadding.addPadding(i, paddingAmount);
       let fragment;

--- a/examples/load-manifests-examples.js
+++ b/examples/load-manifests-examples.js
@@ -10,7 +10,8 @@ function addExamples () {
     '-',
     'http://demo.unified-streaming.com/video/ateam/ateam.ism/ateam.mpd',
     'http://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd',
-    'https://dash.edgesuite.net/akamai/bbb_30fps/bbb_30fps.mpd'
+    'https://dash.edgesuite.net/akamai/bbb_30fps/bbb_30fps.mpd',
+    'https://vm2.dashif.org/dash/vod/testpic_2s/multi_subs.mpd'
   ];
   for (let i = 0, j = examples.length; i < j; i++) {
     addExample(examples[i]);

--- a/examples/load-manifests-examples.js
+++ b/examples/load-manifests-examples.js
@@ -9,7 +9,8 @@ function addExamples () {
   const examples = [
     '-',
     'http://demo.unified-streaming.com/video/ateam/ateam.ism/ateam.mpd',
-    'http://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd'
+    'http://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd',
+    'https://dash.edgesuite.net/akamai/bbb_30fps/bbb_30fps.mpd'
   ];
   for (let i = 0, j = examples.length; i < j; i++) {
     addExample(examples[i]);

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const downstreamElectron = require('./api/index');
 // TESTING PRODUCTION
 // const downstreamElectron = require('./dist/index');
 
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
 const exampleFile = `file://${__dirname}/examples/main/index.html`;
 const path = require("path");
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jasmine_test": "./node_modules/jasmine-node/bin/jasmine-node units/ --junitreport --output tmp",
     "jasmine_report": "./node_modules/junit-viewer/bin/junit-viewer --results=tmp/TEST-utildownloadsjs.xml --save=tmp/units_result.html",
     "start": "electron .",
+    "debug": "electron --inspect=5858 .",
     "travis-build": "npm run eslint && npm run jasmine_test && npm run build && npm run jsdoc && true"
   },
   "author": "castlabs GmbH",


### PR DESCRIPTION
Hi,

This PR fixes some pb using segment templates manifest :  

Using manifest  https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd
- BaseURL of segment was not well formed (././.... instead of http://dash.akamaized.net/akamai/bbb_30fps/...)
- Incorrect number of media segments
- Error in SegmentTemplate computing, segment were starting at index 2, instead of index 1

Using manifest https://vm2.dashif.org/dash/vod/testpic_2s/multi_subs.mpd : 
- Incorrect number of mediaUrl objects

To test these manifests, in example, I have added process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"; to ignore self-certificate errors. This is only set in electron sample, not in library

Regards
Jeremie