### PR TITLE
Fix a pb of proxy settings in main process 

### DIFF
--- a/api/manifest/loader/manifest-loader.js
+++ b/api/manifest/loader/manifest-loader.js
@@ -1,5 +1,5 @@
 "use strict";
-const request = require('request');
+const electronFetch = require('electron-fetch');
 const appSettings = require('../../app-settings');
 
 const ManifestLoader = (function () {
@@ -11,18 +11,17 @@ const ManifestLoader = (function () {
   ManifestLoader.prototype.sendXMLHttpRequest = function (url) {
     const defaultOptions = Object.assign({}, appSettings.getSettings().defaultManifestRequestOptions);
     return new Promise(function (resolve, reject) {
-      request.get(url, defaultOptions, function (error, response) {
-        if (!error && response.statusCode >= 400) {
-          error = response.statusMessage;
-        }
-        if (!error) {
-          resolve({response: response.body, url: url});
-        } else {
-          reject(new Error("MANIFEST LOAD FAILURE " + error));
-        }
-      });
+      electronFetch(url, defaultOptions)
+        .then((res) => res.text())
+        .then((body) => {
+          resolve({response: body, url: url});
+        })
+        .catch((err) => {
+          reject(new Error("MANIFEST LOAD FAILURE " + err))
+        });
     });
   };
   return ManifestLoader;
 }());
+
 exports.ManifestLoader = ManifestLoader;

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ const downstreamElectronBE = require('./api/downstream-electron-be');
 //BUILD
 // const downstreamElectronBE = require('./build/downstream-electron-be');
 
+// allow self-signed certificates (this is the case for some Dash.js manifest)
+app.commandLine.appendSwitch('ignore-certificate-errors');
+
 const exampleFile = `file://${__dirname}/examples/main/index.html`;
 const path = require("path");
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jsonfile": "4.0.0",
     "mkdirp": "0.5.1",
     "moment": "2.19.0",
-    "request": "https://github.com/castlabs/request",
+    "electron-fetch": "1.0.0",
     "underscore": "1.8.3",
     "url-parse": "1.1.9",
     "xmldom": "0.1.27"


### PR DESCRIPTION
The main process doesn't use same proxies as renderer process. Thus, if no env proxy is set, the module cannot perform donwload, even though there is a proxy configured in system.

To fix this, use electron-fetch (https://github.com/arantes555/electron-fetch) module instead of request in main process, which is built over electron::net module.
Electron::net uses chromium network library and can then access to system proxy configuration, just like renderer process.

In other word, no more need to set proxy in environment variable for main process.

In index.js file, the line "app.commandLine.appendSwitch('ignore-certificate-errors');" is to ignore self-certificate errors (this is set in sample, not in library)

Jérémie