### PR TITLE
Package.json Fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-preset-env": "1.6.0",
     "clean-webpack-plugin": "0.1.17",
     "eslint": "4.8.0",
+    "electron": "https://github.com/castlabs/electron-releases#v1.8.1-vmp1010",
     "jquery": "3.2.1",
     "jsdoc": "3.5.5",
     "jsdoc-webpack-plugin": "0.0.2",
@@ -35,7 +36,6 @@
   "dependencies": {
     "biguint-format": "1.0.0",
     "cors": "2.8.4",
-    "electron": "https://github.com/castlabs/electron-releases#v1.8.1-vmp1010",
     "express": "4.16.2",
     "flake-idgen": "1.1.0",
     "fs-extra": "4.0.2",


### PR DESCRIPTION
Hi

This PR fixes some dependencies in package.json : 

- electron is a dev dependency (otherwise, electron will be embedded in node_modules of a packaged application -> up to 100Mb of over size !!!! )
- remove electron-window-manager (not used)

Jérémie
