### PR TITLE
MSS support

### DIFF
--- a/api/manifest/loader/manifest.js
+++ b/api/manifest/loader/manifest.js
@@ -2,6 +2,7 @@
 const ManifestLoader = require("./manifest-loader");
 const ManifestLocalLoader = require("./manifest-local-loader");
 const ManifestXML_1 = require("./../parser/manifest-xml");
+const ManifestXML_MSS = require("./../parser/mss/manifest-xml");
 const AllAdaptationSets_1 = require("../parser/all-adaptation-sets");
 const SnowflakeId_1 = require("../../util/snowflake-id");
 const jsonRepresentation = require("../parser/json-representation");
@@ -20,7 +21,11 @@ const Manifest = (function () {
   }
 
   Manifest.prototype.createManifestXML = function (url) {
+    if (typeof ManifestXML_MSS === 'object') {
+      return new ManifestXML_MSS.ManifestXML();
+    } else {
       return new ManifestXML_1.ManifestXML();
+    }
   };
 
   Manifest.prototype.load = function (url) {

--- a/api/manifest/loader/manifest.js
+++ b/api/manifest/loader/manifest.js
@@ -19,6 +19,10 @@ const Manifest = (function () {
     }
   }
 
+  Manifest.prototype.createManifestXML = function (url) {
+      return new ManifestXML_1.ManifestXML();
+  };
+
   Manifest.prototype.load = function (url) {
     const _this = this;
     return new Promise(function (resolve, reject) {
@@ -31,7 +35,8 @@ const Manifest = (function () {
         var isEncodingUTF16 = encoding.isUTF16(v.response);
         v.response = v.response.toString(isEncodingUTF16 ? 'utf16le' : 'utf-8');
         const xml = v.response;
-        _this.manifestXML = new ManifestXML_1.ManifestXML(xml, function () {
+        _this.manifestXML = _this.createManifestXML();
+        _this.manifestXML.parse(xml, function () {
           resolve();
         }, function (e) {
           reject(e);
@@ -49,7 +54,8 @@ const Manifest = (function () {
       ManifestLocalLoader(localPath).then(function (str) {
         _this.url_domain = url.substring(0, url.lastIndexOf('/') + 1);
         _this.manifest_name = url.substring(url.lastIndexOf('/') + 1, url.length);
-        _this.manifestXML = new ManifestXML_1.ManifestXML(str, function () {
+        _this.manifestXML = new ManifestXML_1.ManifestXML();
+        _this.manifestXML.parse(str, function () {
           resolve();
         }, function (e) {
           reject(e);
@@ -64,7 +70,8 @@ const Manifest = (function () {
   Manifest.prototype.loadFromStr = function (str, url) {
     this.url_domain = url.substring(0, url.lastIndexOf('/') + 1);
     this.manifest_name = url.substring(url.lastIndexOf('/') + 1, url.length);
-    this.manifestXML = new ManifestXML_1.ManifestXML(str);
+    this.manifestXML = new ManifestXML_1.ManifestXML();
+    this.manifestXML.parse(str);
   };
 
   Manifest.prototype.getAdaptationSets = function () {

--- a/api/manifest/loader/manifest.js
+++ b/api/manifest/loader/manifest.js
@@ -20,7 +20,7 @@ const Manifest = (function () {
     }
   }
 
-  Manifest.prototype.createManifestXML = function (url) {
+  Manifest.prototype.createManifestXML = function () {
     if (typeof ManifestXML_MSS === 'object') {
       return new ManifestXML_MSS.ManifestXML();
     } else {

--- a/api/manifest/loader/manifest.js
+++ b/api/manifest/loader/manifest.js
@@ -109,6 +109,9 @@ const Manifest = (function () {
   Manifest.prototype.getManifestXML = function () {
     return this.manifestXML.getManifestXML();
   };
+  Manifest.prototype.removeNode = function () {
+    this.manifestXML.removeNode();
+  };
   Manifest.prototype.getJsonInfo = function () {
     let json = {};
     json.id = this.id;

--- a/api/manifest/loader/manifest.js
+++ b/api/manifest/loader/manifest.js
@@ -1,8 +1,8 @@
 "use strict";
 const ManifestLoader = require("./manifest-loader");
 const ManifestLocalLoader = require("./manifest-local-loader");
-const ManifestXML_1 = require("./../parser/manifest-xml");
-const ManifestXML_MSS = require("./../parser/mss/manifest-xml");
+// const ManifestXML_1 = require("./../parser/manifest-xml");
+const ManifestXML_1 = require("./../parser/mss/manifest-xml");
 const AllAdaptationSets_1 = require("../parser/all-adaptation-sets");
 const SnowflakeId_1 = require("../../util/snowflake-id");
 const jsonRepresentation = require("../parser/json-representation");
@@ -20,14 +20,6 @@ const Manifest = (function () {
     }
   }
 
-  Manifest.prototype.createManifestXML = function () {
-    if (typeof ManifestXML_MSS === 'object') {
-      return new ManifestXML_MSS.ManifestXML();
-    } else {
-      return new ManifestXML_1.ManifestXML();
-    }
-  };
-
   Manifest.prototype.load = function (url) {
     const _this = this;
     return new Promise(function (resolve, reject) {
@@ -40,7 +32,7 @@ const Manifest = (function () {
         var isEncodingUTF16 = encoding.isUTF16(v.response);
         v.response = v.response.toString(isEncodingUTF16 ? 'utf16le' : 'utf-8');
         const xml = v.response;
-        _this.manifestXML = _this.createManifestXML();
+        _this.manifestXML = new ManifestXML_1.ManifestXML();
         _this.manifestXML.parse(xml, function () {
           resolve();
         }, function (e) {

--- a/api/manifest/parser/adaptation-set-node.js
+++ b/api/manifest/parser/adaptation-set-node.js
@@ -19,7 +19,11 @@ const AdaptationSetNode = (function (_super) {
     _super.call(this, node, xml);
     this.representationColl = [];
     this.contentProtections = [];
-    const rep = node.getElementsByTagName('Representation');
+    this.parse();
+  }
+
+  AdaptationSetNode.prototype.parse = function() {
+    const rep = this.currentNode.getElementsByTagName('Representation');
     for (let i = 0; i < rep.length; i++) {
       const repNode = new RepresentationNode_1.RepresentationNode(rep[i], this.xml);
       this.representationColl[i] = repNode;
@@ -30,7 +34,7 @@ const AdaptationSetNode = (function (_super) {
       }
     }
 
-    const contentProtections = node.getElementsByTagName('ContentProtection');
+    const contentProtections = this.currentNode.getElementsByTagName('ContentProtection');
     for (let i = 0; i < contentProtections.length; i++) {
       const attrs = contentProtections[i].attributes;
       const cenc = contentProtections[i].getElementsByTagName("cenc:pssh");
@@ -42,7 +46,7 @@ const AdaptationSetNode = (function (_super) {
         this.contentProtections.push(contentProtection);
       }
     }
-  }
+  };
 
   AdaptationSetNode.prototype.getContentProtections = function () {
     return this.contentProtections;

--- a/api/manifest/parser/adaptation-set-node.js
+++ b/api/manifest/parser/adaptation-set-node.js
@@ -22,7 +22,7 @@ const AdaptationSetNode = (function (_super) {
     this.parse();
   }
 
-  AdaptationSetNode.prototype.parse = function() {
+  AdaptationSetNode.prototype.parse = function () {
     const rep = this.currentNode.getElementsByTagName('Representation');
     for (let i = 0; i < rep.length; i++) {
       const repNode = new RepresentationNode_1.RepresentationNode(rep[i], this.xml);

--- a/api/manifest/parser/manifest-xml.js
+++ b/api/manifest/parser/manifest-xml.js
@@ -68,6 +68,7 @@ const ManifestXML = (function () {
     return newDocument;
   };
   ManifestXML.prototype.removeNode = function () {
+    const self = this;
     let representationCollection = this.xml.documentElement.getElementsByTagName(this.getRepresentationNodeName());
     let adaptationCollection = this.xml.documentElement.getElementsByTagName(this.getAdaptationSetNodeName());
     let repArray = [];
@@ -88,7 +89,7 @@ const ManifestXML = (function () {
       adaptationArray[i] = adaptationCollection[i];
     }
     adaptationArray.forEach(function (item) {
-      if (!item.getElementsByTagName('Representation').length) {
+      if (!item.getElementsByTagName(self.getRepresentationNodeName()).length) {
         item.parentNode.removeChild(item);
       }
     });

--- a/api/manifest/parser/manifest-xml.js
+++ b/api/manifest/parser/manifest-xml.js
@@ -2,7 +2,9 @@
 const AdaptationSetNode_1 = require("./adaptation-set-node");
 const DOMParser = require('xmldom').DOMParser;
 const ManifestXML = (function () {
-  function ManifestXML (str, onSuccess, onError) {
+  function ManifestXML () {
+  }
+  ManifestXML.prototype.parse = function (str, onSuccess, onError) {
     let parser;
     if (typeof onSuccess === "function" && typeof onError === "function") {
       parser = new DOMParser({
@@ -17,16 +19,26 @@ const ManifestXML = (function () {
     }
     this.adaptationSetColl = [];
     this.xml = parser.parseFromString(str, "application/xml");
+
+    this.parseAdaptations();
+
+    if (typeof onSuccess === "function") {
+      onSuccess();
+    }
+  };
+  ManifestXML.prototype.getAdaptationSetNodeName = function () {
+    return 'AdaptationSet';
+  };
+  ManifestXML.prototype.getRepresentationNodeName = function () {
+    return 'Representation';
+  };
+  ManifestXML.prototype.parseAdaptations = function () {
     const adaptations = this.xml.getElementsByTagName('AdaptationSet');
     for (let i = 0; i < adaptations.length; i++) {
       const adaptNode = new AdaptationSetNode_1.AdaptationSetNode(adaptations[i], this.xml);
       this.adaptationSetColl[i] = adaptNode;
     }
-    if (typeof onSuccess === "function") {
-      onSuccess();
-    }
-  }
-
+  };
   ManifestXML.prototype.getVideoAdaptation = function () {
     return this.getAdaptations('video');
   };
@@ -55,9 +67,12 @@ const ManifestXML = (function () {
     newDocument.appendChild(newNode);
     return newDocument;
   };
-  ManifestXML.removeNode = function (clone) {
-    const representationCollection = clone.documentElement.getElementsByTagName('Representation');
-    const adaptationCollection = clone.documentElement.getElementsByTagName('AdaptationSet');
+  ManifestXML.prototype.removeNode = function () {
+    let adaptationSetName = this.getAdaptationSetNodeName();
+    let representationName = this.getRepresentationNodeName();
+        
+    let representationCollection = this.xml.documentElement.getElementsByTagName(representationName);
+    let adaptationCollection = this.xml.documentElement.getElementsByTagName(adaptationSetName);
     let repArray = [];
     let adaptationArray = [];
     for (let i = 0; i < representationCollection.length; i++) {
@@ -80,7 +95,6 @@ const ManifestXML = (function () {
         item.parentNode.removeChild(item);
       }
     });
-    return clone;
   };
   return ManifestXML;
 }());

--- a/api/manifest/parser/manifest-xml.js
+++ b/api/manifest/parser/manifest-xml.js
@@ -70,7 +70,7 @@ const ManifestXML = (function () {
   ManifestXML.prototype.removeNode = function () {
     let adaptationSetName = this.getAdaptationSetNodeName();
     let representationName = this.getRepresentationNodeName();
-        
+
     let representationCollection = this.xml.documentElement.getElementsByTagName(representationName);
     let adaptationCollection = this.xml.documentElement.getElementsByTagName(adaptationSetName);
     let repArray = [];

--- a/api/manifest/parser/manifest-xml.js
+++ b/api/manifest/parser/manifest-xml.js
@@ -68,11 +68,8 @@ const ManifestXML = (function () {
     return newDocument;
   };
   ManifestXML.prototype.removeNode = function () {
-    let adaptationSetName = this.getAdaptationSetNodeName();
-    let representationName = this.getRepresentationNodeName();
-
-    let representationCollection = this.xml.documentElement.getElementsByTagName(representationName);
-    let adaptationCollection = this.xml.documentElement.getElementsByTagName(adaptationSetName);
+    let representationCollection = this.xml.documentElement.getElementsByTagName(this.getRepresentationNodeName());
+    let adaptationCollection = this.xml.documentElement.getElementsByTagName(this.getAdaptationSetNodeName());
     let repArray = [];
     let adaptationArray = [];
     for (let i = 0; i < representationCollection.length; i++) {

--- a/api/manifest/parser/mss/fragment-information.js
+++ b/api/manifest/parser/mss/fragment-information.js
@@ -22,7 +22,7 @@ const FragmentInformation = (function (_super) {
       this.mediaTemplate = this.segmentTemplate.media;
       this.mediaTemplate = this.replace$Bandwidth$(this.mediaTemplate, this.bandwidth);
     }
-    if(this.segmentTemplate.media) {
+    if (this.segmentTemplate.media) {
       this.timelineItemList = this.segmentTemplate.SegmentTimeline;
     }
     this.createFragmentUrlsFromTimeline(this.timelineItemList);

--- a/api/manifest/parser/mss/fragment-information.js
+++ b/api/manifest/parser/mss/fragment-information.js
@@ -1,0 +1,41 @@
+"use strict";
+const __extends = (this && this.__extends) || function (d, b) {
+      for (let p in b) {
+        if (b.hasOwnProperty(p)) {
+          d[p] = b[p];
+        }
+      }
+      function __ () {
+        this.constructor = d;
+      }
+
+      d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+const MediaUrl_1 = require("../media-url");
+const SegmentInformation_1 = require("../segment-information");
+const FragmentInformation = (function (_super) {
+  __extends(FragmentInformation, _super);
+  function FragmentInformation (presentationDuration, bandwidth, baseUrl, representationID, mimeType, segmentTemplate) {
+    _super.call(this, presentationDuration, bandwidth, baseUrl, representationID, mimeType);
+    if (segmentTemplate) {
+      this.segmentTemplate = segmentTemplate;
+      this.mediaTemplate = this.segmentTemplate.media;
+      this.mediaTemplate = this.replace$Bandwidth$(this.mediaTemplate, this.bandwidth);
+    }
+    if(this.segmentTemplate.media) {
+      this.timelineItemList = this.segmentTemplate.SegmentTimeline;
+    }
+    this.createFragmentUrlsFromTimeline(this.timelineItemList);
+  }
+
+  FragmentInformation.prototype.createFragmentUrlsFromTimeline = function (segmentNodes) {
+    for (let i = 0; i < segmentNodes.S.length; i++) {
+      let fragment = this.mediaTemplate;
+      fragment = this.replace$Time$(fragment, segmentNodes.S[i].t);
+
+      this.mediaUrls.push(new MediaUrl_1.MediaUrl(this.baseUrl, fragment, this.mimeType));
+    }
+  };
+  return FragmentInformation;
+}(SegmentInformation_1.SegmentInformation));
+exports.FragmentInformation = FragmentInformation;

--- a/api/manifest/parser/mss/manifest-xml.js
+++ b/api/manifest/parser/mss/manifest-xml.js
@@ -24,7 +24,7 @@ ManifestXML_1.ManifestXML.prototype._parseAdaptations = ManifestXML_1.ManifestXM
 ManifestXML_1.ManifestXML.prototype.parseAdaptations = function () {
   // Manifest type detection
   this.manifestType = this.getManifestType(this.xml);
-    
+
   if (this.manifestType === 'MSS') {
     return this.parseStreams();
   } else {

--- a/api/manifest/parser/mss/manifest-xml.js
+++ b/api/manifest/parser/mss/manifest-xml.js
@@ -1,0 +1,35 @@
+"use strict";
+const ManifestXML_1 = require('../manifest-xml');
+const StreamIndexNode_1 = require('./streamIndex-node');
+
+
+ManifestXML_1.ManifestXML.prototype.getManifestType = function (xml) {
+  return xml.getElementsByTagName('SmoothStreamingMedia').length !== 0 ? 'MSS' : 'DASH';
+};
+
+ManifestXML_1.ManifestXML.prototype.getAdaptationSetNodeName = function () {
+  return (this.manifestType === 'MSS') ? 'StreamIndex' : 'AdaptationSet';
+};
+ManifestXML_1.ManifestXML.prototype.getRepresentationNodeName = function () {
+  return (this.manifestType === 'MSS') ? 'QualityLevel' : 'Representation';
+};
+ManifestXML_1.ManifestXML.prototype.parseStreams = function () {
+  const streams = this.xml.getElementsByTagName('StreamIndex');
+  for (let i = 0; i < streams.length; i++) {
+    const streamNode = new StreamIndexNode_1.StreamIndexNode(streams[i], this.xml);
+    this.adaptationSetColl[i] = streamNode;
+  }
+};
+ManifestXML_1.ManifestXML.prototype._parseAdaptations = ManifestXML_1.ManifestXML.prototype.parseAdaptations;
+ManifestXML_1.ManifestXML.prototype.parseAdaptations = function () {
+  // Manifest type detection
+  this.manifestType = this.getManifestType(this.xml);
+    
+  if (this.manifestType === 'MSS') {
+    return this.parseStreams();
+  } else {
+    return this._parseAdaptations();
+  }
+};
+
+exports.ManifestXML = ManifestXML_1.ManifestXML;

--- a/api/manifest/parser/mss/qualityLevel-node.js
+++ b/api/manifest/parser/mss/qualityLevel-node.js
@@ -1,0 +1,180 @@
+"use strict";
+const __extends = (this && this.__extends) || function (d, b) {
+  for (let p in b) {
+    if (b.hasOwnProperty(p)) {
+      d[p] = b[p];
+    }
+  }
+  function __ () {
+    this.constructor = d;
+  }
+
+  d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+
+const RepresentationNode_1 = require("../representation-node");
+const IsoDurationParser_1 = require("../../../util/Iso-duration-parser");
+const FragmentInformation_1 = require("./fragment-information");
+const TIME_SCALE_100_NANOSECOND_UNIT = 10000000.0;
+const QualityLevelNode = (function (_super) {
+  __extends(QualityLevelNode, _super);
+  function QualityLevelNode (node, xml) {
+    _super.call(this, node, xml);
+  }
+
+  QualityLevelNode.prototype.createSegmentInformation = function () {
+    const presentationDuration = IsoDurationParser_1.IsoDurationParser.getDuration(parseFloat(this.attributeList['Duration']/TIME_SCALE_100_NANOSECOND_UNIT));
+    const representationID = this.attributeList['id'];
+
+    this.bandwidth = (this.attributeList['bandwidth']) ? parseInt(this.attributeList['bandwidth']) : -1;
+
+    this.segmentTemplate = this.mapMssSegmentTemplate();
+    this.segmentInformation = new FragmentInformation_1.FragmentInformation(presentationDuration, this.bandwidth, this.baseURL, representationID, this.attributeList['mimeType'], this.segmentTemplate);
+  };
+
+  QualityLevelNode.prototype.mapMssSegmentTemplate = function() {
+    let segmentTemplate = {};
+    let mediaUrl;
+
+    mediaUrl = this.attributeList['Url'].replace('{bitrate}', '$Bandwidth$');
+    mediaUrl = mediaUrl.replace('{start time}', '$Time$');
+
+    segmentTemplate.media = mediaUrl;
+    segmentTemplate.timescale = TIME_SCALE_100_NANOSECOND_UNIT;
+
+    segmentTemplate.SegmentTimeline = this.mapMssSegmentTimeline();
+
+    return segmentTemplate;
+  };
+
+  QualityLevelNode.prototype.mapMssSegmentTimeline = function() {
+    let segmentTimeline = {};
+    let chunks = this.currentNode.parentNode.getElementsByTagName('c');
+    let segments = [];
+    let segment;
+    let prevSegment;
+    let tManifest;
+    let i;
+    let duration = 0;
+
+    for (i = 0; i < chunks.length; i++) {
+        segment = {};
+
+        // Get time 't' attribute value
+        tManifest = chunks[i].getAttribute('t');
+
+        // => segment.tManifest = original timestamp value as a string (for constructing the fragment request url, see DashHandler)
+        // => segment.t = number value of timestamp (maybe rounded value, but only for 0.1 microsecond)
+        segment.tManifest = parseFloat(tManifest);
+        segment.t = parseFloat(tManifest);
+
+        // Get duration 'd' attribute value
+        segment.d = parseFloat(chunks[i].getAttribute('d'));
+
+        // If 't' not defined for first segment then t=0
+        if ((i === 0) && !segment.t) {
+            segment.t = 0;
+        }
+
+        if (i > 0) {
+            prevSegment = segments[segments.length - 1];
+            // Update previous segment duration if not defined
+            if (!prevSegment.d) {
+                if (prevSegment.tManifest) {
+                    prevSegment.d = parseFloat(tManifest) - parseFloat(prevSegment.tManifest);
+                } else {
+                    prevSegment.d = segment.t - prevSegment.t;
+                }
+            }
+            // Set segment absolute timestamp if not set in manifest
+            if (!segment.t) {
+                if (prevSegment.tManifest) {
+                    segment.tManifest = parseFloat(prevSegment.tManifest) + prevSegment.d;
+                    segment.t = parseFloat(segment.tManifest);
+                } else {
+                    segment.t = prevSegment.t + prevSegment.d;
+                }
+            }
+        }
+
+        duration += segment.d;
+
+        // Create new segment
+        segments.push(segment);
+    }
+
+    segmentTimeline.S = segments;
+    segmentTimeline.S_asArray = segments;
+    segmentTimeline.duration = duration / TIME_SCALE_100_NANOSECOND_UNIT;
+
+    return segmentTimeline;
+  };
+
+  QualityLevelNode.prototype.writeAttributesToList = function (node, list) {
+    const attrList = node.attributes;
+    const mimeTypeMap = {
+      'video': 'video/mp4',
+      'audio': 'audio/mp4',
+      'text': 'application/mp4'
+    };
+    for (let i = 0; i < node.childNodes.length; i++) {
+      if (!this.baseURL && node.childNodes[i].nodeName == 'BaseURL') {
+        this.baseURL = node.childNodes[i].firstChild.nodeValue;
+      }
+      if (!this.segmentBase && node.childNodes[i].nodeName == 'SegmentBase') {
+        this.segmentBase = node.childNodes[i];
+      }
+      if (!this.segmentTemplate && node.childNodes[i].nodeName == 'SegmentTemplate') {
+        this.segmentTemplate = node.childNodes[i];
+      }
+      if (!this.segmentList && node.childNodes[i].nodeName == 'SegmentList') {
+        this.segmentList = node.childNodes[i];
+      }
+    }
+    for (let attr in attrList) {
+      if (!list[attrList[attr].nodeName]) {
+        list[attrList[attr].nodeName] = attrList[attr].nodeValue;
+      }
+    }
+
+    if (list['Type'] !== undefined){
+      list['contentType'] = list['Type'];
+      list['mimeType'] = mimeTypeMap[list['contentType']];
+      list['bandwidth'] = list['Bitrate'];
+      list['width'] = list['MaxWidth'];
+      list['height'] = list['MaxHeight'];
+      list.lang = list['Language'] || 'und';
+
+      let indexId = list['Name'] ? list['Name'] : list['Type'];
+      // build id
+      list['id'] = indexId + '_' + list['Index'];
+
+      if(list['Type'] === 'audio' ) {
+        list.audioSamplingRate = list['SamplingRate'];
+      }
+    }
+
+    if (node.parentNode !== null) {
+      this.buildAttributeList(node.parentNode, list);
+    } else {
+      if (!this.segmentInformation) {
+        this.createSegmentInformation();
+      }
+    }
+    _super.prototype.writeAttributesToList.call(this, node, list);
+  };
+  QualityLevelNode.prototype.getMimeType = function () {
+    return this.attributeList['mimeType'];
+  };
+  QualityLevelNode.prototype.hasMimeType = function () {
+    return this.attributeList['mimeType'] ? true : false;
+  };
+  QualityLevelNode.prototype.getContentType = function () {
+    return this.attributeList['contentType'];
+  };
+  QualityLevelNode.prototype.hasContentType = function () {
+    return this.attributeList['contentType'] ? true : false;
+  };
+  return QualityLevelNode;
+}(RepresentationNode_1.RepresentationNode));
+exports.QualityLevelNode = QualityLevelNode;

--- a/api/manifest/parser/mss/qualityLevel-node.js
+++ b/api/manifest/parser/mss/qualityLevel-node.js
@@ -12,7 +12,7 @@ const __extends = (this && this.__extends) || function (d, b) {
   d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 
-const RepresentationNode_1 = require("../representation-node");
+const ManifestNode_1 = require("../manifest-node");
 const IsoDurationParser_1 = require("../../../util/Iso-duration-parser");
 const FragmentInformation_1 = require("./fragment-information");
 const TIME_SCALE_100_NANOSECOND_UNIT = 10000000.0;
@@ -176,5 +176,5 @@ const QualityLevelNode = (function (_super) {
     return this.attributeList['contentType'] ? true : false;
   };
   return QualityLevelNode;
-}(RepresentationNode_1.RepresentationNode));
+}(ManifestNode_1.ManifestNode));
 exports.QualityLevelNode = QualityLevelNode;

--- a/api/manifest/parser/mss/qualityLevel-node.js
+++ b/api/manifest/parser/mss/qualityLevel-node.js
@@ -23,7 +23,7 @@ const QualityLevelNode = (function (_super) {
   }
 
   QualityLevelNode.prototype.createSegmentInformation = function () {
-    const presentationDuration = IsoDurationParser_1.IsoDurationParser.getDuration(parseFloat(this.attributeList['Duration']/TIME_SCALE_100_NANOSECOND_UNIT));
+    const presentationDuration = IsoDurationParser_1.IsoDurationParser.getDuration(parseFloat(this.attributeList['Duration'] / TIME_SCALE_100_NANOSECOND_UNIT));
     const representationID = this.attributeList['id'];
 
     this.bandwidth = (this.attributeList['bandwidth']) ? parseInt(this.attributeList['bandwidth']) : -1;
@@ -32,7 +32,7 @@ const QualityLevelNode = (function (_super) {
     this.segmentInformation = new FragmentInformation_1.FragmentInformation(presentationDuration, this.bandwidth, this.baseURL, representationID, this.attributeList['mimeType'], this.segmentTemplate);
   };
 
-  QualityLevelNode.prototype.mapMssSegmentTemplate = function() {
+  QualityLevelNode.prototype.mapMssSegmentTemplate = function () {
     let segmentTemplate = {};
     let mediaUrl;
 
@@ -47,7 +47,7 @@ const QualityLevelNode = (function (_super) {
     return segmentTemplate;
   };
 
-  QualityLevelNode.prototype.mapMssSegmentTimeline = function() {
+  QualityLevelNode.prototype.mapMssSegmentTimeline = function () {
     let segmentTimeline = {};
     let chunks = this.currentNode.parentNode.getElementsByTagName('c');
     let segments = [];
@@ -137,7 +137,7 @@ const QualityLevelNode = (function (_super) {
       }
     }
 
-    if (list['Type'] !== undefined){
+    if (list['Type'] !== undefined) {
       list['contentType'] = list['Type'];
       list['mimeType'] = mimeTypeMap[list['contentType']];
       list['bandwidth'] = list['Bitrate'];
@@ -149,7 +149,7 @@ const QualityLevelNode = (function (_super) {
       // build id
       list['id'] = indexId + '_' + list['Index'];
 
-      if(list['Type'] === 'audio' ) {
+      if (list['Type'] === 'audio' ) {
         list.audioSamplingRate = list['SamplingRate'];
       }
     }

--- a/api/manifest/parser/mss/streamIndex-node.js
+++ b/api/manifest/parser/mss/streamIndex-node.js
@@ -1,0 +1,193 @@
+"use strict";
+const BASE64 = require('base64-js');
+const DOMParser = require('xmldom').DOMParser;
+
+const __extends = (this && this.__extends) || function (d, b) {
+      for (let p in b) {
+        if (b.hasOwnProperty(p)) {
+          d[p] = b[p];
+        }
+      }
+      function __ () {
+        this.constructor = d;
+      }
+
+      d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+const AdaptationSetNode_1 = require("../adaptation-set-node");
+const QualityLevelNode_1 = require("./qualityLevel-node");
+
+const StreamIndexNode = (function (_super) {
+  __extends(StreamIndexNode, _super);
+  function StreamIndexNode (node, xml) {
+    _super.call(this, node, xml);
+  }
+
+  StreamIndexNode.prototype.parse = function() {
+  
+    let qualityLevels = this.currentNode.getElementsByTagName('QualityLevel');
+
+    for (let i = 0; i < qualityLevels.length; i++) {
+      const qualityLevelNode = new QualityLevelNode_1.QualityLevelNode(qualityLevels[i], this.xml);
+      this.representationColl[i] = qualityLevelNode;
+      if (this.representationColl[0].hasMimeType()) {
+          this.attributeList['mimeType'] = this.representationColl[0].getMimeType();
+      }
+      if (this.representationColl[0].hasContentType()) {
+        this.attributeList['mimeType'] = this.representationColl[0].getContentType();
+      }
+    }
+    
+    const protection = this.xml.getElementsByTagName('Protection')[0];
+
+    if (protection !== undefined) {
+      const protectionHeader = protection.getElementsByTagName('ProtectionHeader')[0];
+      // Some packagers put newlines into the ProtectionHeader base64 string, which is not good
+      // because this cannot be correctly parsed. Let's just filter out any newlines found in there.
+      const psshPR = protectionHeader.firstChild.data.replace(/\n|\r/g, '');
+  
+      // Get KID (in CENC format) from protection header
+      const KID = this.getKIDFromProtectionHeader(protectionHeader);
+  
+      // Create ContentProtection for PlayReady
+      const cpPR = {
+        schemeIdUri: "urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95",
+        cencPSSH: psshPR
+      };     
+      this.contentProtections.push(cpPR);
+  
+      // Create ContentProtection for Widevine (as a CENC protection)
+      const psshWV = this.createWidevinePssh(KID);
+      const cpWV = {
+        schemeIdUri: "urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed",
+        cencPSSH: psshWV
+      };      
+      this.contentProtections.push(cpWV);  
+    }
+  }
+
+  StreamIndexNode.prototype.getKIDFromProtectionHeader = function(protectionHeader) {
+      let prHeader,
+          wrmHeader,
+          xmlReader,
+          KID;
+
+      // Get PlayReady header as byte array (base64 decoded)
+      prHeader = BASE64.toByteArray(protectionHeader.firstChild.data);
+
+      // Get Right Management header (WRMHEADER) from PlayReady header
+      wrmHeader = this.getWRMHeaderFromPRHeader(prHeader);
+
+      // Convert from multi-byte to unicode
+      wrmHeader = new Uint16Array(wrmHeader.buffer);
+
+      // Convert to string
+      wrmHeader = String.fromCharCode.apply(null, wrmHeader);
+
+      // Parse <WRMHeader> to get KID field value
+      xmlReader = (new DOMParser()).parseFromString(wrmHeader, 'application/xml');
+      KID = xmlReader.getElementsByTagName('KID')[0].textContent;
+
+      // Get KID (base64 decoded) as byte array
+      KID = BASE64.toByteArray(KID);
+
+      // Convert UUID from little-endian to big-endian
+      this.convertUuidEndianness(KID);
+
+      return KID;
+  };
+
+  StreamIndexNode.prototype.convertUuidEndianness = function(uuid) {
+      this.swapBytes(uuid, 0, 3);
+      this.swapBytes(uuid, 1, 2);
+      this.swapBytes(uuid, 4, 5);
+      this.swapBytes(uuid, 6, 7);
+  };
+
+  StreamIndexNode.prototype.swapBytes = function(bytes, pos1, pos2) {
+      let temp = bytes[pos1];
+      bytes[pos1] = bytes[pos2];
+      bytes[pos2] = temp;
+  };
+
+  StreamIndexNode.prototype.getWRMHeaderFromPRHeader = function getWRMHeaderFromPRHeader(prHeader) {
+    let length,
+        recordCount,
+        recordType,
+        recordLength,
+        recordValue;
+    let i = 0;
+
+    // Parse PlayReady header
+
+    // Length - 32 bits (LE format)
+    length = (prHeader[i + 3] << 24) + (prHeader[i + 2] << 16) + (prHeader[i + 1] << 8) + prHeader[i];
+    i += 4;
+
+    // Record count - 16 bits (LE format)
+    recordCount = (prHeader[i + 1] << 8) + prHeader[i];
+    i += 2;
+
+    // Parse records
+    while (i < prHeader.length) {
+        // Record type - 16 bits (LE format)
+        recordType = (prHeader[i + 1] << 8) + prHeader[i];
+        i += 2;
+
+        // Check if Rights Management header (record type = 0x01)
+        if (recordType === 0x01) {
+
+            // Record length - 16 bits (LE format)
+            recordLength = (prHeader[i + 1] << 8) + prHeader[i];
+            i += 2;
+
+            // Record value => contains <WRMHEADER>
+            recordValue = new Uint8Array(recordLength);
+            recordValue.set(prHeader.subarray(i, i + recordLength));
+            return recordValue;
+        }
+    }
+    return null;
+  };
+  StreamIndexNode.prototype.createWidevinePssh = function(KID) {
+    // Create Widevine CENC header (Protocol Buffer) with KID value
+    var wvCencHeader = new Uint8Array(2 + KID.length);
+    wvCencHeader[0] = 0x12;
+    wvCencHeader[1] = 0x10;
+    wvCencHeader.set(KID, 2);
+
+    // Create a pssh box
+    var length = 12 /* box length, type, version and flags */ + 16 /* SystemID */ + 4 /* data length */ + wvCencHeader.length,
+        pssh = new Uint8Array(length),
+        i = 0;
+
+    // Set box length value
+    pssh[i++] = (length & 0xFF000000) >> 24;
+    pssh[i++] = (length & 0x00FF0000) >> 16;
+    pssh[i++] = (length & 0x0000FF00) >> 8;
+    pssh[i++] = (length & 0x000000FF);
+
+    // Set type ('pssh'), version (0) and flags (0)
+    pssh.set([0x70, 0x73, 0x73, 0x68, 0x00, 0x00, 0x00, 0x00], i);
+    i += 8;
+
+    // Set SystemID ('edef8ba9-79d6-4ace-a3c8-27dcd51d21ed')
+    pssh.set([0xed, 0xef, 0x8b, 0xa9,  0x79, 0xd6, 0x4a, 0xce, 0xa3, 0xc8, 0x27, 0xdc, 0xd5, 0x1d, 0x21, 0xed], i);
+    i += 16;
+
+    // Set data length value
+    pssh[i++] = (wvCencHeader.length & 0xFF000000) >> 24;
+    pssh[i++] = (wvCencHeader.length & 0x00FF0000) >> 16;
+    pssh[i++] = (wvCencHeader.length & 0x0000FF00) >> 8;
+    pssh[i++] = (wvCencHeader.length & 0x000000FF);
+
+    // Copy Widevine CENC header
+    pssh.set(wvCencHeader, i);
+
+    // Convert to BASE64 string
+    pssh = BASE64.fromByteArray (pssh);
+    return pssh;
+  };  
+  return StreamIndexNode;
+}(AdaptationSetNode_1.AdaptationSetNode));
+exports.StreamIndexNode = StreamIndexNode;

--- a/api/util/parse-manifest-with-choosen-representations.js
+++ b/api/util/parse-manifest-with-choosen-representations.js
@@ -2,7 +2,6 @@
 const constants = require("../constants");
 
 const Manifest = require("../manifest/loader/manifest").Manifest;
-const ManifestXML = require("../manifest/parser/manifest-xml").ManifestXML;
 
 const XMLSerializer = require("xmldom").XMLSerializer;
 

--- a/api/util/parse-manifest-with-choosen-representations.js
+++ b/api/util/parse-manifest-with-choosen-representations.js
@@ -74,9 +74,9 @@ function parseManifestWithChoosenRepresentations (manifest, representations) {
   fixBaseURL(manifest.getAudioRepresentations());
   fixBaseURL(manifest.getTextRepresentations());
 
-  let manifestXML = ManifestXML.removeNode(manifest.getManifestXML());
+  manifest.removeNode();
 
-  return xmlSerializer.serializeToString(manifestXML);
+  return xmlSerializer.serializeToString(manifest.getManifestXML());
 }
 
 module.exports = parseManifestWithChoosenRepresentations;

--- a/examples/load-manifests-examples.js
+++ b/examples/load-manifests-examples.js
@@ -9,7 +9,9 @@ function addExamples () {
   const examples = [
     '-',
     'http://demo.unified-streaming.com/video/ateam/ateam.ism/ateam.mpd',
-    'http://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd'
+    'http://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd',
+    'http://playready.directtaps.net/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/Manifest',
+    'http://playready.directtaps.net/smoothstreaming/SSWSS720H264PR/SuperSpeedway_720.ism/Manifest'
   ];
   for (let i = 0, j = examples.length; i < j; i++) {
     addExample(examples[i]);

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "webpack": "3.6.0"
   },
   "dependencies": {
+    "base64-js": "^1.2.1",
     "biguint-format": "1.0.0",
     "cors": "2.8.4",
     "express": "4.16.2",


### PR DESCRIPTION
This PR adds support for smooth streaming contents.
It provide a mss parser package that extends default DASH parser components.
The ManifestXML component is extended in order to detect stream protocol and then call the appropriate node parsing components.
This PR provides also support for PlayReady to Widevine pssh conversion to enable Widevine persistent license retrieval.

By default mss package is included in output build (downstream-electron-be.js) and make the file increasing from 79KB to 87KB.

But, if desired, we can eventually setup a build option to include or not mss package.