### PR TITLE
Enable create persistent session before starting download

### DIFF
--- a/api/downstream-electron-fe.js
+++ b/api/downstream-electron-fe.js
@@ -9,7 +9,7 @@ let downstreamElectronFE;
 function getWidevinePSSH (info) {
   const manifestProtections = info.manifestInfo.protections;
   let videoRepresentation = manifestProtections.video[0] || {};
-  if (manifestProtections.video) {
+  if (manifestProtections.video && info.manifest.video) {
     videoRepresentation = manifestProtections.video.filter(function (manifestProtection) {
       return info.manifest.video.indexOf(manifestProtection.id) >= 0;
     });

--- a/examples/main/index.js
+++ b/examples/main/index.js
@@ -138,7 +138,7 @@ function addStartActions(manifestId) {
     });
   }));
   //Create Persistent Session
-  $(contentActions).append($('<input type="button" value="Create Persistent Session">').on('click', function () {
+  $('#contentActions').append($('<input type="button" value="Create Persistent Session">').on('click', function () {
     downstreamElectron.downloads.createPersistent(manifestId, persistentConfig).then(function (persistentSessionId) {
       showStatusOK('Create Persistent Session: ' + persistentSessionId, contentStatus);
     }, function (err) {
@@ -147,7 +147,7 @@ function addStartActions(manifestId) {
   }));
 
   //Remove Persistent Session
-  $(contentActions).append($('<input type="button" value="Remove Persistent Session">').on('click', function () {
+  $('#contentActions').append($('<input type="button" value="Remove Persistent Session">').on('click', function () {
     downstreamElectron.downloads.removePersistent(manifestId).then(function (result) {
       showStatusOK('Remove Persistent Session', contentStatus);
     }, function (err) {

--- a/examples/main/index.js
+++ b/examples/main/index.js
@@ -137,6 +137,23 @@ function addStartActions(manifestId) {
       this.checked = !this.checked;
     });
   }));
+  //Create Persistent Session
+  $(contentActions).append($('<input type="button" value="Create Persistent Session">').on('click', function () {
+    downstreamElectron.downloads.createPersistent(manifestId, persistentConfig).then(function (persistentSessionId) {
+      showStatusOK('Create Persistent Session: ' + persistentSessionId, contentStatus);
+    }, function (err) {
+      showStatusError('Create Persistent Session', err, contentStatus);
+    });
+  }));
+
+  //Remove Persistent Session
+  $(contentActions).append($('<input type="button" value="Remove Persistent Session">').on('click', function () {
+    downstreamElectron.downloads.removePersistent(manifestId).then(function (result) {
+      showStatusOK('Remove Persistent Session', contentStatus);
+    }, function (err) {
+      showStatusError('Remove Persistent Session', err, contentStatus);
+    });
+  }));
   $('#contentActions').clone(true).appendTo($('#contentActions2'));
 }
 


### PR DESCRIPTION
This PR enables creating a persistent session (persistent license retrieval) before selecting representations and starting download.
Then, by default, protection information from 1st video representation is considered.