### PR TITLE
Allow for custom manifestId

### DIFF
--- a/api/be-methods-all.js
+++ b/api/be-methods-all.js
@@ -22,7 +22,8 @@ let downloads = {};
  * @param {string} manifestUrl - manifest url
  * @example
  * var url = "http://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd";
- * DownstreamElectronFE.downloads.create(url)
+ * var id = "pre-determined-manifestid"; // nullable
+ * DownstreamElectronFE.downloads.create(url, id)
  *    .then(
  *      function onSuccess(result) {console.log("success", result);},
  *      function onError(err) {console.log("error", err);

--- a/api/be-methods/downloads/create.js
+++ b/api/be-methods/downloads/create.js
@@ -3,9 +3,9 @@
 const Manifest = require("../../manifest/loader/manifest").Manifest;
 const translation = require('../../translation/index');
 
-module.exports = function (api, onSuccess, onFailure, target, manifestUrl) {
+module.exports = function (api, onSuccess, onFailure, target, manifestUrl, manifestId) {
   let manifest = new Manifest();
-  manifest.load(manifestUrl)
+  manifest.load(manifestUrl, manifestId)
       .then(() => {
         api.manifestController.cacheManifest(manifest);
         onSuccess(manifest.getJsonInfo());

--- a/api/be-methods/downloads/create.js
+++ b/api/be-methods/downloads/create.js
@@ -4,8 +4,8 @@ const Manifest = require("../../manifest/loader/manifest").Manifest;
 const translation = require('../../translation/index');
 
 module.exports = function (api, onSuccess, onFailure, target, manifestUrl, manifestId) {
-  let manifest = new Manifest();
-  manifest.load(manifestUrl, manifestId)
+  let manifest = new Manifest(manifestId);
+  manifest.load(manifestUrl)
       .then(() => {
         api.manifestController.cacheManifest(manifest);
         onSuccess(manifest.getJsonInfo());


### PR DESCRIPTION
This change will allow for a custom manifest id to be sent during the downstreamElectronFE.downlodas.create process.  The method can now take two arguments

1. manifestURL: string
2. manifestId: string