### PR TITLE
add bandwidth field stored in downloaded.json

### DIFF
--- a/api/manifest/json/link-save.js
+++ b/api/manifest/json/link-save.js
@@ -5,6 +5,7 @@ module.exports = function LinkSave (attr) {
   fieldsPicker(this, [
     "id",
     "contentType",
+    "bandwidth",
     "remoteUrl",
     "stats",
     "localUrl"


### PR DESCRIPTION
When adding bandwidth field, the downloadedParts info is correct because and the overall progress percentage is a lot more accurate when resuming a download.
