### PR TITLE
Callbacks for downloads object

### DIFF
--- a/api/controllers/downloads-controller.js
+++ b/api/controllers/downloads-controller.js
@@ -450,8 +450,6 @@ DownloadsController.prototype.stop = function (manifestId, onSuccess, onFailure)
         let promises = [];
         for (let i = 0, j = itemsToStop.length; i < j; i++) {
           itemToStop = self.storage.downloading.getItem(manifestId, itemsToStop[i]);
-          itemToStop.events.removeListener("end", self._onDownloadEnd);
-          itemToStop.events.removeListener("error", self._onDownloadError);
           promises.push(itemToStop.stopPromise());
         }
 

--- a/api/downloads/download-file.js
+++ b/api/downloads/download-file.js
@@ -152,7 +152,6 @@ DownloadFile.prototype._initChunk = function (chunkNumber) {
     options.endPosition = size - 1;
   }
   const chunk = new DownloadFileChunk(this._url, options, this._onChunkDownload);
-  // chunk.events.on("download", this._onChunkDownload.bind(this));
   this._chunks.push(chunk);
 };
 

--- a/api/downloads/download.js
+++ b/api/downloads/download.js
@@ -14,9 +14,10 @@ const STATUSES = require("./statuses");
  * @param {object} params - parameters connected with download like id, bandwidth, contentType, remoteUrl, localUrl
  * see util class {@link downloadUtil.getDownloadLinks}
  * @param {object} options - options chosen for whole manifest, like number of chunks, retry,
+ * @param {object} cb - callback
  * @constructor
  */
-function Download (params, options) {
+function Download (params, options, cb) {
   this._defaults = {};
   this._defaults.threads = appSettings.getSettings().downloadingThreadsRules.threads;
   this.status = STATUSES.CREATED;
@@ -27,6 +28,7 @@ function Download (params, options) {
   this._options.maxDownloadChunkInternetRetry = appSettings.getSettings().MAX_INTERNET_ERRORS_DOWNLOAD_CHUNK_RETRY;
   this._options.timeout = appSettings.getSettings().times.DOWNLOAD_TIMEOUT;
   this._options.retryTimeout = appSettings.getSettings().times.RETRY_TIMEOUT;
+  this._cb = cb;
   this.stats = {
     available: 0,
     downloaded: 0,
@@ -79,7 +81,9 @@ Download.prototype._onEnd = function () {
   this.status = STATUSES.FINISHED;
   this._updateStats();
   this._removeEvents();
-  this.events.emit("end", this);
+  if (this._cb && this._cb.end) {
+    this._cb.end(this);
+  }
 };
 
 /**
@@ -96,7 +100,9 @@ Download.prototype._onError = function (data) {
 
   self._removeEvents();
   self._updateStats();
-  self.events.emit("error", self, message);
+  if (this._cb && this._cb.error) {
+    this._cb.error(self, message);
+  }
 };
 
 /**
@@ -162,8 +168,12 @@ Download.prototype.start = function () {
       });
     });
     d.run(function () {
-      self._dl = new DownloadFile(self.remoteUrl, self.localUrl, self._options);
-      self._attachEvents();
+      var cb = {
+        error: self._onError,
+        end: self._onEnd,
+        data: self._onData
+      };
+      self._dl = new DownloadFile(self.remoteUrl, self.localUrl, self._options, cb);
       self._dl.start();
     });
   });
@@ -186,13 +196,13 @@ Download.prototype.stop = function (resolve) {
     d.on('error', function () {
       resolve();
     });
+    self._dl._cb.error = function () {
+      resolve();
+    };
+    self._dl._cb.end = function () {
+      resolve();
+    };
     d.run(function () {
-      self._dl.on('error', function () {
-        resolve();
-      });
-      self._dl.on('end', function () {
-        resolve();
-      });
       self._dl.stop();
     });
   } else {


### PR DESCRIPTION
Hi 

This PR removes use of EventEmitter declaration
Sometimes, it may lead to unhandled event exceptions (for example -> cut network and click stop => display an error)

This PR implements callbacks instead, that are managed by downstream-electron itself. 

Jérémie

