### PR TITLE
Fix an exception if there is no manifest using removePersistent

### DIFF
--- a/api/downstream-electron-fe.js
+++ b/api/downstream-electron-fe.js
@@ -128,10 +128,10 @@ DownstreamElectronFE.prototype.downloads.createPersistent = function (args, reso
  */
 DownstreamElectronFE.prototype.downloads.removePersistent = function (args, resolve, reject, manifest) {
   if (this._persistent) {
-    if (!manifest.persistent) {
-      reject('persistent session doesn\'t exist:');
-    } else {
+    if (manifest && manifest.persistent) {
       this._persistent.removePersistentSession(manifest.persistent).then(resolve, reject);
+    } else {
+      resolve();
     }
   } else {
     reject('No persistent plugin initialized');
@@ -489,4 +489,3 @@ module.exports = {
     return downstreamElectronFE;
   }
 };
-


### PR DESCRIPTION
Hi 

This PR fixes an error if manifest is undefined using removePersistent.
The function just acts like DownstreamElectronFE.prototype.downloads.remove by calling resolve in this case 

Jérémie