### PR TITLE
Fix a regression from PR #33

### DIFF
--- a/api/be-methods/downloads/start.js
+++ b/api/be-methods/downloads/start.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const translation = require("../../translation/index");
-const canCreateManifest = require("../../util/can-create-manifest");
 
 module.exports = function (api, onSuccess, onFailure, target, manifestId, representations) {
   const manifest = api.manifestController.getManifestById(manifestId);

--- a/api/be-methods/downloads/start.js
+++ b/api/be-methods/downloads/start.js
@@ -10,20 +10,16 @@ module.exports = function (api, onSuccess, onFailure, target, manifestId, repres
     return;
   }
 
-  canCreateManifest(manifestId).then(function () {
-    api.downloadsController.storage.getItem(manifestId).then(function (result) {
-      if (result) {
-        onFailure(translation.getError(translation.e.downloads.ALREADY_STARTED, manifestId));
-      } else {
-        api.downloadsController.start(manifestId, representations, onSuccess, function (err) {
-          onFailure(translation.getError(translation.e.downloads._GENERAL), err);
-        });
-      }
-    }, function (err) {
-      onFailure(translation.getError(translation.e.downloads._GENERAL), err);
-    });
+  api.downloadsController.storage.getItem(manifestId).then(function (result) {
+    if (result) {
+      onFailure(translation.getError(translation.e.downloads.ALREADY_STARTED, manifestId));
+    } else {
+      api.downloadsController.start(manifestId, representations, onSuccess, function (err) {
+        onFailure(translation.getError(translation.e.downloads._GENERAL), err);
+      });
+    }
   }, function (err) {
-    onFailure(translation.getError(translation.e.manifests.FOLDER_ALREADY_EXISTS, manifestId), err);
+    onFailure(translation.getError(translation.e.downloads._GENERAL), err);
   });
 
 };

--- a/examples/main/index.js
+++ b/examples/main/index.js
@@ -2,8 +2,21 @@
 window.$ = window.jQuery = require('jquery');
 const { remote } = require('electron');
 
+let persistentPlugin = {
+  createPersistentSession : function () {
+    return new Promise ((resolve, reject ) => {
+      resolve('PERSISTENTID');
+    })
+  },
+  removePersistentSession : function () {
+    return new Promise ((resolve, reject ) => {
+      resolve();
+    });
+  }
+}
+
 // DEV
-const downstreamElectron = require('../../api/index').init(window);
+const downstreamElectron = require('../../api/index').init(window, persistentPlugin);
 // TESTING PRODUCTION
 // const downstreamElectron = require('../../dist/index').init(window);
 


### PR DESCRIPTION
Hi 
This PR fixes a regression from PR #33 
 
If a persistent session has been created before downloading chunks, the download fails with an error : folder with manifest id already exists.

In this PR i have created a fake persistent plugin in  examples/main/index.js (it only returns a fake session id).

To test the PR 

- choose a stream and click submit
- create a persistent session
- select representations
- start download -> donwload is OK

If you follow the same instructions with code of PR #33 (using a fake persistent plugin), it will fail with an error 😀 

2018-04-23 15:34:13.910 start FAILED
{"code":22,"errorId":"6394206607781134336","keys":[{"manifestId":"6394206591318491136"}],"msg":"Folder for manifest with id ='6394206591318491136' already exists."}

The scenario is our use case : we must download the session before downloading chunks

Jeremie