### PR TITLE
Add support for fetching a new persistent license when one already exists

### DIFF
--- a/api/be-methods-all.js
+++ b/api/be-methods-all.js
@@ -68,6 +68,31 @@ downloads.create = require('./be-methods/downloads/create');
 downloads.createPersistent = require('./be-methods/downloads/createPersistent');
 
 /**
+ * update a persistent session
+ * @method updatePersistent
+ * @memberOf DownstreamElectronFE.downloads
+ * @param {string} manifestId - manifest identifier
+ * @param {PersistentConfig} config - persistent configuration
+ * @example
+ * var config = {
+ *   licenseUrl: 'https://lic.staging.drmtoday.com/license-proxy-widevine/cenc/',
+ *   serverCertificate: new Uint8Array(<server_certificate>),
+ *   customData: {
+ *     userId: '<user_id>',
+ *     sessionId: '<session_id>',
+ *     merchant: '<merchant>'
+ *   }
+ * };
+ * DownstreamElectronFE.downloads.updatePersistent(manifestId, config)
+ *    .then(
+ *      function onSuccess(result) {console.log("success", result);},
+ *      function onError(err) {console.log("error", err);
+ *    })
+ * @returns {Promise} - promise
+ */
+downloads.updatePersistent = require('./be-methods/downloads/updatePersistent');
+
+/**
  * get ids of all downloads
  * @method getList
  * @memberOf DownstreamElectronFE.downloads

--- a/api/be-methods/downloads/updatePersistent.js
+++ b/api/be-methods/downloads/updatePersistent.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function (api, onSuccess /*, onFailure, target, manifestId */) {
+  onSuccess();
+};

--- a/api/downstream-electron-fe.js
+++ b/api/downstream-electron-fe.js
@@ -83,7 +83,8 @@ function DownstreamElectronFE (window, persistent) {
     'stop',
     'stopAll',
     'subscribe',
-    'unsubscribe'
+    'unsubscribe',
+    'updatePersistent'
   ]);
   this._attachEvents();
 }
@@ -119,6 +120,33 @@ DownstreamElectronFE.prototype.downloads.createPersistent = function (args, reso
         }, reject);
       }
     }, reject);
+  } else {
+    reject('No persistent plugin initialized');
+  }
+};
+
+/**
+ * Creates or updates a persistent session in renderer process using external plugin defined as {@link Persistent}
+ * @param {array} args - arguments
+ * @param {function} resolve - should called on success
+ * @param {function} reject - should called on failure
+ * @returns {void}
+ */
+DownstreamElectronFE.prototype.downloads.updatePersistent = function (args, resolve, reject) {
+  const manifestId = args[0];
+  const config = args[1];
+  const scope = this;
+  if (this._persistent) {
+    this.downloads.info(manifestId).then(function (info) {
+      if (!config.pssh) {
+        config.pssh = getWidevinePSSH(info);
+      }
+      scope._persistent.createPersistentSession(config).then(function (persistentSessionId) {
+        scope.downloads.savePersistent(manifestId, persistentSessionId).then(resolve, reject);
+        resolve(persistentSessionId);
+        // success
+      }, reject);
+    });
   } else {
     reject('No persistent plugin initialized');
   }


### PR DESCRIPTION
Add a new API method `updatePersistent`, which is like `createPersistent` except it skips the test for a persistent already existing.

Our application requests time restricted licenses for offline playback and periodically refreshes licenses in the background. Without this change, we need to do a `removePersistent` before `createPersistent`, which creates a short window where playback is not possible while the license is being updated.