### PR TITLE
do not concatenate error message in chunk files

### DIFF
--- a/api/downloads/download-file-chunk.js
+++ b/api/downloads/download-file-chunk.js
@@ -158,9 +158,11 @@ Chunk.prototype.start = function () {
             }
           });
           response.on("data", function (data) {
-            self.available += data.length;
-            self.downloaded += data.length;
-            self.events.emit("download", data.length);
+            if (response.statusCode === 200 || response.statusCode === 206) {
+              self.available += data.length;
+              self.downloaded += data.length;
+              self.events.emit("download", data.length);
+            }
           });
           response.pipe(self.fileStream);
     });


### PR DESCRIPTION
When we get an error when trying to download a chunk, then the response message (for ex: 400 Bad Request) is concatenate inside the chunk file. This is because response.on('data' ...) is called also for HTTP response errors with content in their body.
This PR fix this problem. We take the content of the body only in case of a 200 or 206 status code