### PR TITLE
remove request chunkedEncoding option (it's only useful for POST)

### DIFF
--- a/api/downloads/download-file-chunk.js
+++ b/api/downloads/download-file-chunk.js
@@ -139,7 +139,6 @@ Chunk.prototype.start = function () {
     }
 
     self._req = net.request(req_options);
-    self._req.chunkedEncoding = true;
 
     self._req.on('response', (response) => {
         response.on("error", function (error) {

--- a/api/downloads/download-file.js
+++ b/api/downloads/download-file.js
@@ -256,7 +256,6 @@ DownloadFile.prototype.start = function () {
     downloadFileUtil.defaultOptions
   );
   let req = net.request(req_options);
-  req.chunkedEncoding = true;
 
   req.on('response', (response) => {
     if (response && response.statusCode >= 400) {

--- a/api/manifest/loader/manifest-loader.js
+++ b/api/manifest/loader/manifest-loader.js
@@ -16,7 +16,6 @@ const ManifestLoader = (function () {
 
     return new Promise(function (resolve, reject) {
       let req = net.request(req_options);
-      req.chunkedEncoding = true;
 
       req.on('error', (err) => {
         reject(err);


### PR DESCRIPTION
As far as I understand it is not useful to set HTTP header Transfer-Encoding : Chunked in a request (except if you do a POST with a body)
This PR removes the request.chunkedEncoding option as downstream only use HEAD or GET request (no body)
We had some troubles with our server, not happy with the Transfer-Encoding : Chunked with HEAD  request => 400 Bad Request
You mentioned in #43  "some servers doesn't work correctly with default electron net class when "chunkedEncoding" has default value". What was the behaviour with those servers ? Are you sure your fix solved it ? For us it introduced a big issue with a lot of 400 errors, partially solved with #44.
If it is really needed in some cases (which I doubt) maybe we could add it as a configuration and not as a default. 