### PR TITLE
Add duration of each representation. 

### DIFF
--- a/api/manifest/json/audio-representation.js
+++ b/api/manifest/json/audio-representation.js
@@ -6,6 +6,7 @@ module.exports = function AudioRepresentation (attr) {
     "audioSamplingRate",
     "bandwidth",
     "id",
-    "lang"
+    "lang",
+    "durationInS"
   ], attr);
 };

--- a/api/manifest/json/text-representation.js
+++ b/api/manifest/json/text-representation.js
@@ -4,6 +4,7 @@ module.exports = function TextRepresentation (attr) {
   fieldsPicker(this, [
     "bandwidth",
     "id",
-    "lang"
+    "lang",
+    "durationInS"
   ], attr);
 };

--- a/api/manifest/json/video-representation.js
+++ b/api/manifest/json/video-representation.js
@@ -6,6 +6,7 @@ module.exports = function VideoRepresentation (attr) {
     "id",
     "height",
     "lang",
-    "width"
+    "width",
+    "durationInS"
   ], attr);
 };

--- a/api/manifest/parser/mss/qualityLevel-node.js
+++ b/api/manifest/parser/mss/qualityLevel-node.js
@@ -154,6 +154,10 @@ const QualityLevelNode = (function (_super) {
       }
     }
 
+    if (list['Duration'] !== undefined) {
+      list['durationInS'] = this.attributeList['Duration'] / TIME_SCALE_100_NANOSECOND_UNIT;
+    }
+
     if (node.parentNode !== null) {
       this.buildAttributeList(node.parentNode, list);
     } else {

--- a/api/manifest/parser/representation-node.js
+++ b/api/manifest/parser/representation-node.js
@@ -65,6 +65,11 @@ const RepresentationNode = (function (_super) {
         list[attrList[attr].nodeName] = attrList[attr].nodeValue;
       }
     }
+    if (list['mediaPresentationDuration'] !== undefined) {
+      list['durationInS'] = IsoDurationParser_1.IsoDurationParser.getDurationAsS(
+        this.attributeList['mediaPresentationDuration']);
+    }
+
     if (node.parentNode !== null) {
       this.buildAttributeList(node.parentNode, list);
     } else {

--- a/api/util/Iso-duration-parser.js
+++ b/api/util/Iso-duration-parser.js
@@ -8,6 +8,10 @@ const IsoDurationParser = (function () {
     const dur = moment.duration(val);
     return dur.asMilliseconds();
   };
+  IsoDurationParser.getDurationAsS = function (val) {
+    const dur = moment.duration(val);
+    return dur.asSeconds();
+  };
   IsoDurationParser.getMoment = function () {
     return moment;
   };


### PR DESCRIPTION
Hi

This PR adds duration to reprensentation informations when getting manifest.
The idea is to estimate the size of each representation on disk, to check available space before downloading chunks

Jérémie