### PR TITLE
License updating

### DIFF
--- a/api/downstream-electron-fe.js
+++ b/api/downstream-electron-fe.js
@@ -118,9 +118,13 @@ DownstreamElectronFE.prototype.downloads.createPersistent = function (args, reso
         scope._persistent.createPersistentSession(config).then(function (persistentSessionId) {
           scope.downloads.savePersistent(manifestId, persistentSessionId).then(function () {
             if (existingPersistentSessionId) {
-              scope._persistent.removePersistentSession(existingPersistentSessionId).then(function () {
+              scope._persistent.removePersistentSession(existingPersistentSessionId)
+              .then(function () {
                 resolve(persistentSessionId);
-              }, reject);
+              })
+              .catch(function () {
+                resolve(persistentSessionId);
+              });
             } else {
               resolve(persistentSessionId);
             }


### PR DESCRIPTION
When we update a license using createPersistent() method, if the removal of previous license fails while new license has been successfully acquired, then the method rejects the promise.
The removal may fail since the license may have been loaded/used by a player for example. Then we get the EME error QuotaExceededError when trying the load the corresponding MediaKeySession in order to remove the license.
An example of scenario that illustrates the issue is the renewal of license that will expires in a while, while the license is being used to playback the stream.

With this PR, the promise is always resolved if new license has been successfully acquired, even if removal of previous license fails.
