### PR TITLE
Waiting status for manifest downloads

### DIFF
--- a/api/controllers/downloads-controller.js
+++ b/api/controllers/downloads-controller.js
@@ -565,8 +565,6 @@ DownloadsController.prototype.startQueue = function (nextManifestPositionInArray
       this.storage.status.setItem(manifestId, "status", STATUSES.WAITING);
     }
     return;
-  } else {
-    this.storage.status.setItem(manifestId, "status", STATUSES.STARTED);
   }
 
   if (!manifestId) {

--- a/api/controllers/downloads-controller.js
+++ b/api/controllers/downloads-controller.js
@@ -554,7 +554,6 @@ DownloadsController.prototype._addLinkToDownload = function (manifestId, link) {
  * @returns {void}
  */
 DownloadsController.prototype.startQueue = function (nextManifestPositionInArray) {
-  const self = this;
   let count, downloadsInProgress, link, manifestId, maxDownloads;
   if (typeof nextManifestPositionInArray === "undefined") {
     nextManifestPositionInArray = 0;

--- a/api/controllers/downloads-controller.js
+++ b/api/controllers/downloads-controller.js
@@ -566,7 +566,7 @@ DownloadsController.prototype.startQueue = function (nextManifestPositionInArray
     }
     return;
   } else {
-    this.storage.status.setItem(manifestId, "status", STATUSES.CREATED);
+    this.storage.status.setItem(manifestId, "status", STATUSES.STARTED);
   }
 
   if (!manifestId) {

--- a/api/controllers/downloads-controller.js
+++ b/api/controllers/downloads-controller.js
@@ -565,6 +565,8 @@ DownloadsController.prototype.startQueue = function (nextManifestPositionInArray
       this.storage.status.setItem(manifestId, "status", STATUSES.WAITING);
     }
     return;
+  } else {
+    this.storage.status.setItem(manifestId, "status", STATUSES.STARTED);
   }
 
   if (!manifestId) {

--- a/api/controllers/downloads-controller.js
+++ b/api/controllers/downloads-controller.js
@@ -106,6 +106,16 @@ DownloadsController.prototype._downloadOrderGetManifestId = function (nextManife
 
 /**
  *
+ * @param {manifestId} manifestId -  manifest identifier
+ * @returns {number} index number from array _manifestsDownloadOrder
+ * @private
+ */
+DownloadsController.prototype._indexOfManifest = function (manifestId) {
+  return this._manifestsDownloadOrder.indexOf(manifestId);
+}
+
+/**
+ *
  * @param {string} manifestId - manifest identifier
  * @returns {*} - if manifest has been already added to the queue
  * @private
@@ -410,7 +420,11 @@ DownloadsController.prototype.start = function (manifestId, representations, onS
                   ])
                   .then(function () {
                     self._addDownloads(manifestId, videoLinks, audioLinks, textLinks);
-                    self.storage.status.setItem(manifestId, "status", STATUSES.STARTED);
+                    if (self._indexOfManifest(manifestId) > appSettings.getSettings().numberOfManifestsInParallel - 1) {
+                      self.storage.status.setItem(manifestId, "status", STATUSES.WAITING);
+                    } else {
+                      self.storage.status.setItem(manifestId, "status", STATUSES.STARTED);
+                    }
                     self.storage.status.setItem(manifestId, "left", self.storage.left.count(manifestId));
                     self.storage.sync(manifestId, [
                           self.storage.stores.DOWNLOADS.DOWNLOADED,

--- a/api/controllers/downloads-controller.js
+++ b/api/controllers/downloads-controller.js
@@ -421,7 +421,7 @@ DownloadsController.prototype.start = function (manifestId, representations, onS
                   .then(function () {
                     self._addDownloads(manifestId, videoLinks, audioLinks, textLinks);
                     if (self._indexOfManifest(manifestId) > appSettings.getSettings().numberOfManifestsInParallel - 1) {
-                      self.storage.status.setItem(manifestId, "status", STATUSES.WAITING);
+                      self.storage.status.setItem(manifestId, "status", STATUSES.QUEUED);
                     } else {
                       self.storage.status.setItem(manifestId, "status", STATUSES.STARTED);
                     }
@@ -576,7 +576,7 @@ DownloadsController.prototype.startQueue = function (nextManifestPositionInArray
   manifestId = this._downloadOrderGetManifestId(nextManifestPositionInArray);
   if (nextManifestPositionInArray >= appSettings.getSettings().numberOfManifestsInParallel) {
     if (manifestId) {
-      this.storage.status.setItem(manifestId, "status", STATUSES.WAITING);
+      this.storage.status.setItem(manifestId, "status", STATUSES.QUEUED);
     }
     return;
   } else {

--- a/api/controllers/downloads-controller.js
+++ b/api/controllers/downloads-controller.js
@@ -554,15 +554,22 @@ DownloadsController.prototype._addLinkToDownload = function (manifestId, link) {
  * @returns {void}
  */
 DownloadsController.prototype.startQueue = function (nextManifestPositionInArray) {
+  const self = this;
   let count, downloadsInProgress, link, manifestId, maxDownloads;
   if (typeof nextManifestPositionInArray === "undefined") {
     nextManifestPositionInArray = 0;
   }
 
-  if (nextManifestPositionInArray >= appSettings.getSettings().numberOfManifestsInParallel) {
-    return;
-  }
   manifestId = this._downloadOrderGetManifestId(nextManifestPositionInArray);
+  if (nextManifestPositionInArray >= appSettings.getSettings().numberOfManifestsInParallel) {
+    if (manifestId) {
+      this.storage.status.setItem(manifestId, "status", STATUSES.WAITING);
+    }
+    return;
+  } else {
+    this.storage.status.setItem(manifestId, "status", STATUSES.CREATED);
+  }
+
   if (!manifestId) {
     count = 0;
     let i, j, items;

--- a/api/downloads/statuses.js
+++ b/api/downloads/statuses.js
@@ -6,6 +6,7 @@ const STATUSES = {
   "STOPPED": "STOPPED",
   "FINISHED": "FINISHED",
   "BROKEN": "BROKEN",
+  "WAITING": "WAITING"
 };
 
 module.exports = STATUSES;

--- a/api/downloads/statuses.js
+++ b/api/downloads/statuses.js
@@ -6,7 +6,7 @@ const STATUSES = {
   "STOPPED": "STOPPED",
   "FINISHED": "FINISHED",
   "BROKEN": "BROKEN",
-  "WAITING": "WAITING"
+  "QUEUED": "QUEUED"
 };
 
 module.exports = STATUSES;

--- a/api/stats/download_stats.js
+++ b/api/stats/download_stats.js
@@ -139,7 +139,8 @@ DownloadStats.prototype._generate = function (refresh) {
     writeProgressDownloaded: 0,
     errors: 0,
     progress: 0,
-    speed: 0
+    speed: 0,
+    status: ''
   };
 
   //availableBytes - bates that has been already downloaded
@@ -198,6 +199,7 @@ DownloadStats.prototype._generate = function (refresh) {
     speed += this._getDiff("downloadedBytes", manifestId, allStats, this._statsPrevious);
     speed = (speed * 1000) / ((now - this._statsTime) || 1  );
     allStats[manifestId].speed = speed;
+    allStats[manifestId].status = this._storage.status.getItem(manifestId, "status");
 
     //progress for downloaded
     let leftParts = countParts(allStats[manifestId].leftI);
@@ -231,6 +233,7 @@ DownloadStats.prototype._generate = function (refresh) {
     }
     showStats[manifestId].speed = allStats[manifestId].speed;
     showStats[manifestId].speedBytes = this._convertToBytes(allStats[manifestId].speed, 3, 2);
+    showStats[manifestId].status = allStats[manifestId].status;
   }
   for (let key in showStats) {
     if (showStats.hasOwnProperty(key)) {


### PR DESCRIPTION
This PR adds a new status for manifest that are queued and waiting because we have reached the maximum of parallel downloads given by the settings appSettings.getSettings().numberOfManifestsInParallel

Without this status we can't know if a download is really currently running or not (status STARTED didn't mean that it was really downloading something)

This allows us to display a special state for pending downloads in our interface.