### PR TITLE
Implements seek during Download

### DIFF
--- a/api/controllers/downloads-controller.js
+++ b/api/controllers/downloads-controller.js
@@ -232,7 +232,6 @@ DownloadsController.prototype._markDownloadItem = function (download) {
 };
 
 /**
- *
  * @param {Download} download - Download Class
  * @param {object} err - error object
  * @returns {void}
@@ -302,6 +301,96 @@ DownloadsController.prototype.isDownloadFinished = function (manifestId) {
  */
 DownloadsController.prototype.isDownloadFinishedAndSynced = function (manifestId) {
   return !this.storage.left.count(manifestId) && !this.storage.downloading.count(manifestId) && !this.storage.keyExists(manifestId);
+};
+
+
+DownloadsController.prototype.getDownloading = function (manifestId, localFile) {
+  let items = this.storage.downloading.getItems(manifestId);
+  if ( !items ) {
+    return null;
+  }
+
+  for (var link in items) {
+    if (items.hasOwnProperty(link)) {
+      let download = items[link];
+      if (download.localUrl === localFile) {
+        return download;
+      }
+    }
+  }
+  return null;
+}
+
+DownloadsController.prototype.waitForDownload = function (download, callback) {
+  let _onDownloadEnd;
+  let _onDownloadError;
+
+  let removeListener = function (download) {
+    download.events.removeListener("end", _onDownloadEnd);
+    download.events.removeListener("error", _onDownloadError);
+  }
+
+  _onDownloadEnd = function (download) {
+    removeListener(download);
+    callback();
+  }
+
+  _onDownloadError = function (download, err) {
+    removeListener(download);
+    callback(err);
+  }
+
+  download.events.on("end", _onDownloadEnd);
+  download.events.on("error", _onDownloadError);
+}
+
+ /**
+ * Perform a seek - this changes order of fragment download for a manifest
+ * @param {string} manifestId - manifest identifier
+ * @param {string} localFile - local file
+ * @param {function} callback - callback to get result
+ * @returns {void}
+ */
+DownloadsController.prototype.performSeek = function (manifestId, localFile, callback) {
+  let self = this;
+  let download;
+
+  download = self.getDownloading(manifestId, localFile);
+  if (download) {
+    self.waitForDownload(download, callback);
+    return;
+  }
+
+  let items = self.storage.left.getItems(manifestId);
+  if ( !items ) {
+    callback('No download found');
+    return;
+  }
+
+  let index = items.findIndex(function (download) {
+    return (download.localUrl === localFile)
+  });
+  if (index > -1) {
+
+    let part1 =  items.slice(0, index);
+    let part2 =  items.slice(index);
+
+    self.storage.left.clear(manifestId);
+    self.storage.left.concat(manifestId, part2);
+    self.storage.left.concat(manifestId, part1);
+
+    items = self.storage.left.getItems(manifestId);
+    self.startQueue(self._indexOfManifest(manifestId), true);
+    download = self.getDownloading(manifestId, localFile);
+    if (download) {
+      self.waitForDownload(download, callback);
+    } else {
+      // if not queued, return an error
+      callback('No download found');
+    }
+  } else {
+    callback('No download found');
+  }
 };
 
 /**
@@ -631,15 +720,18 @@ DownloadsController.prototype._addLinkToDownload = function (manifestId, link) {
   download.events.on("end", self._onDownloadEnd);
   download.events.on("error", self._onDownloadError);
   download.start();
+
+  return download;
 };
 
 /**
  *
  * @param {number} [nextManifestPositionInArray] - index from array to decide which manifest should be downloaded next
  *   (queue)
+ * @param {boolean} forceDownload true to force next download to be queued
  * @returns {void}
  */
-DownloadsController.prototype.startQueue = function (nextManifestPositionInArray) {
+DownloadsController.prototype.startQueue = function (nextManifestPositionInArray, forceDownload) {
   let count, downloadsInProgress, link, manifestId, maxDownloads;
   if (typeof nextManifestPositionInArray === "undefined") {
     nextManifestPositionInArray = 0;
@@ -669,7 +761,7 @@ DownloadsController.prototype.startQueue = function (nextManifestPositionInArray
   }
   downloadsInProgress = this.storage.params.getItem(manifestId, this._names.downloadInProgress);
   maxDownloads = this.storage.params.getItem(manifestId, this._names.maxDownloadInProgress);
-  if (downloadsInProgress < maxDownloads - 1) {
+  if ((downloadsInProgress < maxDownloads - 1) || forceDownload) {
     link = this.storage.left.shift(manifestId);
     if (link) {
       this.storage.params.increase(manifestId, this._names.downloadInProgress);

--- a/api/downstream-electron-be.js
+++ b/api/downstream-electron-be.js
@@ -203,7 +203,7 @@ DownstreamElectronBE.prototype._serveOfflineContent = function () {
   const self = this;
   const maxOfflineContentPortRange = appSettings.getSettings().maxOfflineContentPortRange;
 
-  const server = new Server(this.offlineController, maxOfflineContentPortRange, this._offlineContentPort);
+  const server = new Server(this.offlineController, this.downloadsController, maxOfflineContentPortRange, this._offlineContentPort);
   server.serveOfflineContent( function (offlinePort) {
     self._offlineContentPort = offlinePort;
   })

--- a/api/server/contentRoute.js
+++ b/api/server/contentRoute.js
@@ -1,14 +1,14 @@
 "use strict";
 
 const appSettings = require("../app-settings");
-
+const fs = require('fs');
  /**
  * ContentRoute
  * @param {object} app - express server instance
  * @constructor
  */
 
-function ContentRoute (app, offlineController) {
+function ContentRoute (app, offlineController, downloadController) {
 
   /*------------------------------------------------------------------------------------------*/
 
@@ -39,11 +39,40 @@ function ContentRoute (app, offlineController) {
       };
 
       let file = downloadFolder + '/' + manifestId + '/' + req.params[0];
-      res.sendFile(file, options, function (err) {
-        if (err && err.status) {
-          res.status(err.status).end();
+
+      let downloadedCallback = function (err) {
+        if (err) {
+          return res.status(404).end();
         }
-      });
+
+        // no error => file has been downloaded
+        res.sendFile(file, options, function (err) {
+          if (err && err.status) {
+            res.status(err.status).end();
+          }
+        });
+      }
+
+      // check if file exists
+      fs.exists(file, (exists) => {
+        if (exists) {
+          // let's check that file is not being downloading
+          let download = downloadController.getDownloading(manifestId, file);
+          if (download) {
+            // file is created but being downloading => wait for download before sending result
+            downloadController.waitForDownload(download, downloadedCallback);
+          } else {
+            res.sendFile(file, options, function (err) {
+              if (err && err.status) {
+                res.status(err.status).end();
+              }
+            });
+          }
+        } else {
+          // let's check if file is goigin to be downloaded => if so let's perform seek and send file once downloaded
+          downloadController.performSeek(manifestId, file, downloadedCallback);
+        }
+      })
     });
   });
 }

--- a/api/server/server.js
+++ b/api/server/server.js
@@ -9,18 +9,20 @@ const isPortTaken = require('../util/is-port-taken');
 /**
  * Offline content server
  * @param {object} offlineController : offline controller
+ * @param {object} downloadController : download controller
  * @param {string} maxOfflineContentPortRange - max range for offline port to on which content can be served
  * @param {string} offlineContentPort - on which port offline content should be served, default is 3010
  * @constructor
  */
-function OfflineContentServer (offlineController, maxOfflineContentPortRange, offlineContentPort) {
+function OfflineContentServer (offlineController, downloadController, maxOfflineContentPortRange, offlineContentPort) {
   this._offlineController = offlineController;
+  this._downloadController = downloadController;
   this._maxOfflineContentPortRange = maxOfflineContentPortRange;
   this._offlineContentPort = offlineContentPort;
   this._server = express();
   this._server.use(cors());
 
-  require('./contentRoute')(this._server, this._offlineController);
+  require('./contentRoute')(this._server, this._offlineController, this._downloadController);
 }
 
 /**


### PR DESCRIPTION
This commit implements seek during download.

Local server check if asked file is already downloaded, or not. If not, then the server checks if asked file is part of downloaded stream. If so, download list order of fragment is changed so that asked file is downloaded first.

Jérémie