### PR TITLE
Fix a pb in startQueue

### DIFF
--- a/api/controllers/downloads-controller.js
+++ b/api/controllers/downloads-controller.js
@@ -771,6 +771,10 @@ DownloadsController.prototype.startQueue = function (nextManifestPositionInArray
   }
 
   manifestId = this._downloadOrderGetManifestId(nextManifestPositionInArray);
+  if (manifestId && this.isDownloadFinished(manifestId)) {
+    // the manifest id will be removed from queue, wait next time. Thus, do not change status
+    return;
+  }
   if (nextManifestPositionInArray >= appSettings.getSettings().numberOfManifestsInParallel) {
     if (manifestId) {
       this.storage.status.setItem(manifestId, "status", STATUSES.QUEUED);


### PR DESCRIPTION
High

This PR solves a pb in downloadController::startQueue method.
A FINISHED download should not be set in STARTED status. This can happen with several downloads in parallel

Jérémie