### PR TITLE
Resume method - do not reset status to CREATED

### DIFF
--- a/api/controllers/downloads-controller.js
+++ b/api/controllers/downloads-controller.js
@@ -468,6 +468,7 @@ DownloadsController.prototype.performSeek = function (manifestId, localFile, cal
  * @param {function} onSuccess - callback to be invoked when start has been successfully
  * @param {function} onFailure - callback to be invoked when start failed
  * @param {boolean} fromResumed - if start has been called from resume api method
+ * @param {string} oldstatus - if from resumed, then indicates the old status of download
  * @returns {void}
  */
 DownloadsController.prototype.start = function (manifestId, representations, downloadFolder,  onSuccess, onFailure, fromResumed, oldstatus) {


### PR DESCRIPTION
Hi

This PR fix a pb using resume API. 
In method start, the status was always initialized to CREATED, even using resume API. In this case, status should be initialized using last known status.

Jérémie