### PR TITLE
HTTP server : check status of manifest

### DIFF
--- a/api/server/server.js
+++ b/api/server/server.js
@@ -69,7 +69,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
       callback(data.port);
     }
 
-    if (data.cmd === 'get_folder') {
+    if (data.cmd === 'get_info') {
 
       let requestId = data.requestId;
       // http server asks data folder for manifest id
@@ -88,7 +88,7 @@ OfflineContentServer.prototype._startServer = function (port, callback) {
         }
 
         // send response back
-        return self.childProcess.send({status: 'OK', requestId: requestId, result: {folder: downloadFolder}});
+        return self.childProcess.send({status: 'OK', requestId: requestId, result: {folder: downloadFolder, status: info.status}});
       })
     }
 


### PR DESCRIPTION
Hi

This PR adds an optimization for HTTP server content route. The status of manifest is checked. If status is finished, there is no need to check if fragment is being downloaded. 

It avoids interprocess message between server and downstream main process

Jeremie