### PR TITLE
Add a preference to stop on download error.

### DIFF
--- a/api/app-settings.js
+++ b/api/app-settings.js
@@ -83,6 +83,7 @@ let settings = {
   offlineContentPortStart: 3010,
   maxOfflineContentPortRange: 3030,
   numberOfManifestsInParallel: 2,
+  stopOnError: false,
   stores: {
     DOWNLOADS: {
       "LEFT": "left",
@@ -155,6 +156,9 @@ function loadUserSettings (jsonSettings) {
     }
     if (jsonSettings.numberOfManifestsInParallel) {
       settings.numberOfManifestsInParallel = jsonSettings.numberOfManifestsInParallel;
+    }
+    if (jsonSettings.stopOnError !== undefined) {
+      settings.stopOnError = jsonSettings.stopOnError;
     }
     if (jsonSettings.customManifestIdFolderRegex) {
       settings.customManifestIdFolderRegex = jsonSettings.customManifestIdFolderRegex;

--- a/api/controllers/downloads-controller.js
+++ b/api/controllers/downloads-controller.js
@@ -299,13 +299,13 @@ DownloadsController.prototype._stopWithStatus = function (manifestId, onSuccess,
 DownloadsController.prototype._onDownloadError = function (download, err) {
   console.error("ERROR", download.remoteUrl, err);
   this._markDownloadItem(download);
-  if (err === downloadFileUtil.errors.NO_SPACE_LEFT_ERROR) {
+  if (err === downloadFileUtil.errors.NO_SPACE_LEFT_ERROR || appSettings.getSettings().stopOnError) {
     // stop downloading => cannot write
     this._stopWithStatus(download.manifestId, () => {
       console.info('stopped');
     }, (failure) => {
       console.info(failure);
-    }, STATUSES.ERROR, downloadFileUtil.errors.NO_SPACE_LEFT_ERROR);
+    }, STATUSES.ERROR, err);
   }
 };
 


### PR DESCRIPTION
Hi

Default behaviour of downstream on download error is to continue downloading others fragments.
This PR adds a preference to stop downloading when error occurs.

Jérémie

