### PR TITLE
add an option to force no cache for downloads

### DIFF
--- a/api/app-settings.js
+++ b/api/app-settings.js
@@ -103,6 +103,7 @@ let settings = {
   },
   useChunkedEncoding: false,
   useHeadRequests: true,
+  noCache: false,
   defaultManifestRequestOptions: {
     headers: {
       "Accept": "*/*",
@@ -179,6 +180,9 @@ function loadUserSettings (jsonSettings) {
     }
     if (jsonSettings.MAX_ERRORS_DOWNLOAD_CHUNK_RETRY) {
       settings.MAX_ERRORS_DOWNLOAD_CHUNK_RETRY = jsonSettings.MAX_ERRORS_DOWNLOAD_CHUNK_RETRY;
+    }
+    if (jsonSettings.noCache) {
+      settings.noCache = jsonSettings.noCache
     }
   }
 

--- a/api/downloads/download-file-no-head.js
+++ b/api/downloads/download-file-no-head.js
@@ -168,6 +168,12 @@ DownloadFileNoHead.prototype.start = function () {
     url: this._url,
   };
 
+  if (this._options.noCache) {
+    req_options.headers = {
+      'Cache-Control': 'no-cache'
+    }
+  }
+
   self._createFileStream(function (err) {
     if (err) {
       self._retry(downloadFileUtil.errors.FILE_CREATING_ERROR, function (retried) {

--- a/api/downloads/download-file.js
+++ b/api/downloads/download-file.js
@@ -272,6 +272,11 @@ DownloadFile.prototype.start = function () {
     },
     downloadFileUtil.defaultOptions
   );
+  if (this._options.noCache) {
+    req_options.headers = req_options. headers || {};
+    req_options.headers['Cache-Control'] = 'no-cache';
+  }
+
   let req = net.request(req_options);
   req.chunkedEncoding = this._options.useChunkedEncoding;
 

--- a/api/downloads/download-file.js
+++ b/api/downloads/download-file.js
@@ -273,7 +273,7 @@ DownloadFile.prototype.start = function () {
     downloadFileUtil.defaultOptions
   );
   if (this._options.noCache) {
-    req_options.headers = req_options. headers || {};
+    req_options.headers = req_options.headers || {};
     req_options.headers['Cache-Control'] = 'no-cache';
   }
 

--- a/api/downloads/download.js
+++ b/api/downloads/download.js
@@ -30,6 +30,7 @@ function Download (params, options) {
   this._options.retryTimeout = appSettings.getSettings().times.RETRY_TIMEOUT;
   this._options.useChunkedEncoding = appSettings.getSettings().useChunkedEncoding;
   this._options.useHeadRequests = appSettings.getSettings().useHeadRequests;
+  this._options.noCache = appSettings.getSettings().noCache;
   this.stats = {
     available: 0,
     downloaded: 0,


### PR DESCRIPTION
In order to force requests to be sent to the server, add an option to ignore local cache.
It can be useful in case of 404 errors, they might be cached by chromium and if we want to retry a download, we want to be sure that requests are sent to the server and not handled by the local cache.