### PR TITLE
Manifest.js - LoadFromLocal 

### DIFF
--- a/api/manifest/loader/manifest.js
+++ b/api/manifest/loader/manifest.js
@@ -53,7 +53,7 @@ const Manifest = (function () {
     const _this = this;
     return new Promise(function (resolve, reject) {
       if (!url || !localPath) {
-        reject();
+        reject('wrong parameter');
         return;
       }
       ManifestLocalLoader(localPath).then(function (str) {


### PR DESCRIPTION
adds an error on loadFromLocal rejection if url or local path is not set