### PR TITLE
create - Add a string parameter to let application give the manaifest data

### DIFF
--- a/api/manifest/loader/manifest.js
+++ b/api/manifest/loader/manifest.js
@@ -49,6 +49,19 @@ const Manifest = (function () {
     });
   };
 
+Manifest.prototype.loadWithManifest = function (url, manifest) {
+    const _this = this;
+    return new Promise(function (resolve, reject) {
+        _this._setUpUrl(url);
+        _this.manifestXML = new ManifestXML_1.ManifestXML();
+        _this.manifestXML.parse(manifest, function () {
+            resolve();
+        }, function (e) {
+            reject(e);
+            throw new Error("Manifest parsing error");
+        });
+    });
+};
   Manifest.prototype.loadFromLocal = function (localPath, url) {
     const _this = this;
     return new Promise(function (resolve, reject) {


### PR DESCRIPTION
Hi

This PR adds a string parameter to download.create back end API, so that applciation is able to give manifest string to downstream.

The idea here is to let application download the manifest and gives the result as parameter to create a download

Jérémie