### PR TITLE
manage HTTP2 or SPDY errors during download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ dist
 gh-pages
 
 # folder where offline settings are being kept
+public
 .settings
 settings
 *.zip

--- a/api/downloads/download.js
+++ b/api/downloads/download.js
@@ -114,7 +114,7 @@ Download.prototype._onDomainError = function (data) {
   const message = data.message || "";
 
   if (self._dl) {
-    if (message === 'net::ERR_NETWORK_CHANGED') {
+    if (message === 'net::ERR_NETWORK_CHANGED' || message === 'net::ERR_SPDY_PROTOCOL_ERROR' || message === 'net::ERR_HTTP2_PROTOCOL_ERROR') {
       // network changed during download, retry download
       self.stop(() => {
         self.start();

--- a/examples/main/load-manifests-examples.js
+++ b/examples/main/load-manifests-examples.js
@@ -12,7 +12,8 @@ function addExamples () {
     'http://demo.unified-streaming.com/video/ateam/ateam.ism/ateam.mpd',
     'http://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd',
     'http://playready.directtaps.net/smoothstreaming/SSWSS720H264/SuperSpeedway_720.ism/Manifest',
-    'http://playready.directtaps.net/smoothstreaming/SSWSS720H264PR/SuperSpeedway_720.ism/Manifest'
+    'http://playready.directtaps.net/smoothstreaming/SSWSS720H264PR/SuperSpeedway_720.ism/Manifest',
+    'https://media.axprod.net/TestVectors/v7-Clear/Manifest.mpd'
   ];
 
   for (let i = 0, j = examples.length; i < j; i++) {


### PR DESCRIPTION
When we download fragments on an https domain, it is done with HTTP2 or SPDY protocol (depending on the electron version) thanks to net.request.
I have added a MPD example hosted on a https domain to test that case.

When this HTTP2 mode is activated, we may encounter some specific errors that were not treated.
With this PR we simply retry the requests that fails with a specific HTTP2 or SPDY protocol error.

To mitigate the HTTP2 errors, we could also reduce the values of downloadingThreadsRules, because for big videos we may have up to 50 simultaneous requests (defined in [app-settings.js](https://github.com/castlabs/downstream_electron/blob/8a96a683683e51cd4cbe06129bbc235cb6616224/api/app-settings.js#L65)) which is a lot. Errors happen when we have low/medium bandwidth but it happens quite often.

