### PR TITLE
Support of electron 9

### DIFF
--- a/api/downstream-electron-be.js
+++ b/api/downstream-electron-be.js
@@ -13,6 +13,14 @@ const Server = require('./server/server.js');
 
 let DownstreamElectronBE;
 
+function deserialize (serializedJavascript) {
+  try {
+    return JSON.parse(serializedJavascript);
+  } catch (err) {
+    return {};
+  }
+}
+
 /**
  * @constructor
  * @namespace DownstreamElectronBE
@@ -182,7 +190,7 @@ DownstreamElectronBE.prototype._getMethod = function (methodName) {
  */
 DownstreamElectronBE.prototype._onApiRequest = function (evt, data, target) {
   const promiseId = data.promiseId;
-  const argsObj = data.args || {};
+  const argsObj = deserialize(data.args) || {};
   const method = data.method;
   const windowId = data.windowId;
   target = windowId;

--- a/api/downstream-electron-fe.js
+++ b/api/downstream-electron-fe.js
@@ -9,6 +9,10 @@ const translation = require("./translation/index");
 
 let downstreamElectronFE;
 
+function serialize (obj) {
+  return JSON.stringify(obj);
+}
+
 function getWidevinePSSH (info) {
   const manifestProtections = info.manifestInfo.protections;
   let videoRepresentation = manifestProtections.video[0] || {};
@@ -247,7 +251,7 @@ DownstreamElectronFE.prototype._apiCall = function (method, args, originalMethod
   request.promiseId = promiseId;
   request.method = method;
   request.windowId = this._windowId;
-  request.args = args;
+  request.args = serialize(args);
   this._send(request);
   return promise;
 };
@@ -388,7 +392,7 @@ DownstreamElectronFE.prototype._removeSubscribers = function () {
     }
   }
   request.method = 'removeSubscribers';
-  request.args = [subscribersId];
+  request.args = serialize([subscribersId]);
 
   this._send(request);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1163,9 +1163,9 @@
       }
     },
     "@electron/get": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.10.0.tgz",
-      "integrity": "sha512-hlueNXU51c3CwQjBw/i5fwt+VfQgSQVUTdicpCHkhEjNZaa4CXJ5W1GaxSwtLE2dvRmAHjpIjUMHTqJ53uojfg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.12.2.tgz",
+      "integrity": "sha512-vAuHUbfvBQpYTJ5wB7uVIDq5c/Ry0fiTBMs7lnEYAo/qXXppIVcWdfBr57u6eRnKdVso7KSiH6p/LbQAG6Izrg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -1200,9 +1200,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "dev": true
         },
         "jsonfile": {
@@ -2596,8 +2596,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
       "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -3725,8 +3724,8 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron": {
-      "version": "git+https://github.com/castlabs/electron-releases.git#611e63296fc1324e2603e1e0a13c5b6e4cfbd4cf",
-      "from": "git+https://github.com/castlabs/electron-releases.git#v8.2.3-wvvmp",
+      "version": "git+https://github.com/castlabs/electron-releases.git#f75ede820bc063ee06d9a1b47db62efba3065707",
+      "from": "git+https://github.com/castlabs/electron-releases.git#v9.1.1-wvvmp",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -3735,9 +3734,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.36",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.36.tgz",
-          "integrity": "sha512-hmmypvyO/uTLFYCYu6Hlb3ydeJ11vXRxg8/WJ0E3wvwmPO0y47VqnfmXFVuWlysO0Zyj+je1Y33rQeuYkZ51GQ==",
+          "version": "12.12.53",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
+          "integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ==",
           "dev": true
         }
       }
@@ -4769,8 +4768,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4791,14 +4789,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4813,20 +4809,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4943,8 +4936,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4956,7 +4948,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4971,7 +4962,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4979,14 +4969,12 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5005,7 +4993,6 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -5067,8 +5054,7 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -5096,8 +5082,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5109,7 +5094,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5187,8 +5171,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5224,7 +5207,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5244,7 +5226,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5288,14 +5269,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5396,19 +5375,19 @@
       }
     },
     "global-agent": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.8.tgz",
-      "integrity": "sha512-VpBe/rhY6Rw2VDOTszAMNambg+4Qv8j0yiTNDYEXXXxkUNGWLHp8A3ztK4YDBbFNcWF4rgsec6/5gPyryya/+A==",
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.12.tgz",
+      "integrity": "sha512-caAljRMS/qcDo69X9BfkgrihGUgGx44Fb4QQToNQjsiWh+YlQ66uqYVAdA8Olqit+5Ng0nkz09je3ZzANMZcjg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "boolean": "^3.0.0",
-        "core-js": "^3.6.4",
+        "boolean": "^3.0.1",
+        "core-js": "^3.6.5",
         "es6-error": "^4.1.1",
-        "matcher": "^2.1.0",
-        "roarr": "^2.15.2",
-        "semver": "^7.1.2",
-        "serialize-error": "^5.0.0"
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
       },
       "dependencies": {
         "core-js": {
@@ -6502,19 +6481,19 @@
       "dev": true
     },
     "matcher": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-2.1.0.tgz",
-      "integrity": "sha512-o+nZr+vtJtgPNklyeUKkkH42OsK8WAfdgaJE2FNxcjLPg+5QbeEoT6vRj8Xq/iv18JlQ9cmKsEu0b94ixWf1YQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
       "dev": true,
       "optional": true,
       "requires": {
-        "escape-string-regexp": "^2.0.0"
+        "escape-string-regexp": "^4.0.0"
       },
       "dependencies": {
         "escape-string-regexp": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true,
           "optional": true
         }
@@ -8071,13 +8050,22 @@
       }
     },
     "serialize-error": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
-      "integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "type-fest": "^0.8.0"
+        "type-fest": "^0.13.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "serialize-javascript": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "babel-loader": "8.1.0",
     "babel-preset-env": "1.7.0",
     "clean-webpack-plugin": "3.0.0",
-    "electron": "git+https://github.com/castlabs/electron-releases.git#v8.2.3-wvvmp",
+    "electron": "git+https://github.com/castlabs/electron-releases.git#v9.1.1-wvvmp",
     "eslint": "^6.8.0",
     "jasmine-node": "3.0.0",
     "jquery": "3.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,6 +66,7 @@ module.exports = {
     chunkFilename: "[id].chunk.js",
     libraryTarget: "umd"
   },
+  devtool: 'eval-source-map',
 
   module: {
     rules: [


### PR DESCRIPTION
Hi

This PR adds support of electron 9 and above, by serializing objects between main and renderer process

Since elctron 8.0, values sent over IPC are now serialized with Structured Clone Algorithm. In electron 8, only a warning was displayed (https://github.com/electron/electron/blob/master/docs/breaking-changes.md#planned-breaking-api-changes-80)

Starting in Electron 9, sending not serialized objects will throw a 'could not be cloned' error.

Jérémie
